### PR TITLE
adding process-pool

### DIFF
--- a/adaptive_scheduler/scheduler.py
+++ b/adaptive_scheduler/scheduler.py
@@ -216,7 +216,7 @@ class BaseScheduler(metaclass=_RequireAttrsABCMeta):
             return self._process_pool(name)
         else:
             raise NotImplementedError(
-                "Use 'ipyparallel', 'dask-mpi', 'mpi4py' or 'process_pool'."
+                "Use 'ipyparallel', 'dask-mpi', 'mpi4py' or 'process-pool'."
             )
 
     def log_fname(self, name: str) -> str:

--- a/adaptive_scheduler/server_support.py
+++ b/adaptive_scheduler/server_support.py
@@ -520,8 +520,13 @@ def _make_default_run_script(
             raise Exception(msg) from e
         import_line = "from distributed import Client"
         executor_line = "Client()"
+    elif executor_type == "process-pool":
+        import_line = "from concurrent.futures import ProcessPoolExecutor"
+        executor_line = "ProcessPoolExecutor(max_workers=args.n)"
     else:
-        raise NotImplementedError("Use 'ipyparallel', 'dask-mpi' or 'mpi4py'.")
+        raise NotImplementedError(
+            "Use 'ipyparallel', 'dask-mpi', 'mpi4py' or 'process-pool'."
+        )
 
     if os.path.abspath(os.path.dirname(learners_file)) != os.path.abspath(""):
         raise RuntimeError(

--- a/docs/source/FAQ.rst
+++ b/docs/source/FAQ.rst
@@ -98,7 +98,7 @@ For example:
 
 Q: `ipyparallel` doesn't work for me, I want to use `process-pool`, how?
 -----------------------------------------------------------------------------------------------------------------
-**A:** Sometimes `ipyparallel` doesn't import modules correctly on its workers. In this case you can use `process-pool`. You just have to pass ``executor_type="process-pool"`` to `~adaptive_scheduler.scheduler.SLURM` or `~adaptive_scheduler.scheduler.PBS`. Note the `process-pool` uses Python's `ProcessPoolExecutor` for parallelism and cannot be used beyond a since machine (for one learner).
+**A:** Sometimes `ipyparallel` doesn't import modules correctly on its workers. In this case you can use `process-pool`. You just have to pass ``executor_type="process-pool"`` to `~adaptive_scheduler.scheduler.SLURM` or `~adaptive_scheduler.scheduler.PBS`. Note the `process-pool` uses Python's `~concurrent.futures.ProcessPoolExecutor` for parallelism and cannot be used beyond a since machine (for one learner).
 
 Q: Cool! What else should I check out?
 --------------------------------------

--- a/docs/source/FAQ.rst
+++ b/docs/source/FAQ.rst
@@ -96,6 +96,10 @@ For example:
     )
     run_manager.start()
 
+Q: `ipyparallel` doesn't work for me, I want to use `process-pool`, how?
+-----------------------------------------------------------------------------------------------------------------
+**A:** Sometimes `ipyparallel` doesn't import modules correctly on its workers. In this case you can use `process-pool`. You just have to pass ``executor_type="process-pool"`` to `~adaptive_scheduler.scheduler.SLURM` or `~adaptive_scheduler.scheduler.PBS`. Note the `process-pool` uses Python's `ProcessPoolExecutor` for parallelism and cannot be used beyond a since machine (for one learner).
+
 Q: Cool! What else should I check out?
 --------------------------------------
 **A:** There are a bunch of things that are not present in the example notebook, I recommend to take a look at:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -97,6 +97,10 @@ intersphinx_mapping = {
     "mpi4py": ("https://mpi4py.readthedocs.io/en/stable/", None),
     "ipyparallel": ("https://ipywidgets.readthedocs.io/en/stable/", None),
     "dask-mpi": ("http://mpi.dask.org/en/latest/", None),
+    "process-pool": (
+        "https://docs.python.org/3/library/concurrent.futures.html#processpoolexecutor",
+        None,
+    ),
     "distributed": ("https://distributed.dask.org/en/latest/", None),
     "dask": ("https://docs.dask.org/en/latest/", None),
 }

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -97,10 +97,6 @@ intersphinx_mapping = {
     "mpi4py": ("https://mpi4py.readthedocs.io/en/stable/", None),
     "ipyparallel": ("https://ipywidgets.readthedocs.io/en/stable/", None),
     "dask-mpi": ("http://mpi.dask.org/en/latest/", None),
-    "process-pool": (
-        "https://docs.python.org/3/library/concurrent.futures.html#processpoolexecutor",
-        None,
-    ),
     "distributed": ("https://distributed.dask.org/en/latest/", None),
     "dask": ("https://docs.dask.org/en/latest/", None),
 }

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     include_package_data=True,
     maintainer="Bas Nijholt",
     maintainer_email="bas@nijho.lt",
-    description="Run many `adaptive.Learner`s on many cores (>10k) using `mpi4py.futures`, `ipyparallel`, or `dask-mpi`.",
+    description="Run many `adaptive.Learner`s on many cores (>10k) using `mpi4py.futures`, `ipyparallel`, `dask-mpi`, or `process-pool`.",
     long_description=readme,
     long_description_content_type="text/x-rst",
     license="BSD-3",


### PR DESCRIPTION
Adding an option to use ProcessPoolExecutor as the executor for learners. This is necessary b/c ipyparallel doesn't work with some imports (notably FreeCAD), and we can't use MPI b/c a lot of other pieces of code uses MPI. Obviously this limits each learner to one node only, but it does fulfill the pattern where one job occupies a node exclusively and takes full advantage of resources on that node