### PR TITLE
remove the learners_file and pass learners directly

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,2 +1,2 @@
 [settings]
-known_third_party = adaptive,dill,ipyparallel,ipywidgets,nbconvert,numpy,pandas,psutil,setuptools,structlog,tinydb,toolz,tqdm,zmq
+known_third_party = adaptive,cloudpickle,ipyparallel,ipywidgets,numpy,nbconvert,pandas,psutil,setuptools,structlog,tinydb,toolz,tqdm,zmq

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,2 +1,2 @@
 [settings]
-known_third_party = adaptive,cloudpickle,ipyparallel,ipywidgets,numpy,nbconvert,pandas,psutil,setuptools,structlog,tinydb,toolz,tqdm,zmq
+known_third_party = adaptive,cloudpickle,ipyparallel,ipywidgets,jinja2,numpy,nbconvert,pandas,psutil,setuptools,structlog,tinydb,toolz,tqdm,zmq

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,2 +1,2 @@
 [settings]
-known_third_party = adaptive,cloudpickle,ipyparallel,ipywidgets,jinja2,numpy,nbconvert,pandas,psutil,setuptools,structlog,tinydb,toolz,tqdm,zmq
+known_third_party = adaptive,cloudpickle,ipyparallel,ipywidgets,jinja2,nbconvert,numpy,pandas,psutil,setuptools,structlog,tinydb,toolz,tqdm,zmq

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 recursive-include adaptive_scheduler *.py
+include adaptive_scheduler/run_script.py.j2
 include LICENSE
 include README.rst
 include requirements.txt

--- a/adaptive_scheduler/client_support.py
+++ b/adaptive_scheduler/client_support.py
@@ -3,8 +3,9 @@ import datetime
 import logging
 import socket
 from contextlib import suppress
-from typing import Any, Dict, Tuple, Union
+from typing import Any, Dict, List, Tuple, Union
 
+import adaptive
 import psutil
 import structlog
 import zmq
@@ -39,7 +40,7 @@ def _add_log_file_handler(log_fname):
 
 def get_learner(
     url: str, log_fname: str, job_id: str, job_name: str,
-) -> Tuple[str, str]:
+) -> Tuple[adaptive.BaseLearner, Union[str, List[str]]]:
     """Get a learner from the database running at `url` and this learner's
     process will be logged in `log_fname` and running under `job_id`.
 
@@ -57,6 +58,8 @@ def get_learner(
 
     Returns
     -------
+    learner : `adaptive.BaseLearner`
+        Learner that is chosen.
     fname : str
         The filename of the learner that was chosen.
     """

--- a/adaptive_scheduler/client_support.py
+++ b/adaptive_scheduler/client_support.py
@@ -12,11 +12,11 @@ import zmq
 from adaptive import AsyncRunner
 
 from adaptive_scheduler.utils import (
+    _deserialize,
     _get_npoints,
-    deserialize,
+    _serialize,
     log_exception,
     maybe_lst,
-    serialize,
 )
 
 ctx = zmq.Context()
@@ -70,10 +70,10 @@ def get_learner(
     with ctx.socket(zmq.REQ) as socket:
         socket.setsockopt(zmq.LINGER, 0)
         socket.connect(url)
-        socket.send_serialized(("start", job_id, log_fname, job_name), serialize)
+        socket.send_serialized(("start", job_id, log_fname, job_name), _serialize)
         log.info(f"sent start signal, going to wait 60s for a reply.")
         socket.setsockopt(zmq.RCVTIMEO, 60_000)  # timeout after 60s
-        reply = socket.recv_serialized(deserialize)
+        reply = socket.recv_serialized(_deserialize)
         log.info("got reply", reply=str(reply))
         if reply is None:
             msg = f"No learners to be run."
@@ -105,10 +105,10 @@ def tell_done(url: str, fname: str) -> None:
     log.info("goal reached! 🎉🎊🥳")
     with ctx.socket(zmq.REQ) as socket:
         socket.connect(url)
-        socket.send_serialized(("stop", fname), serialize)
+        socket.send_serialized(("stop", fname), _serialize)
         socket.setsockopt(zmq.RCVTIMEO, 10_000)  # timeout after 10s
         log.info("sent stop signal, going to wait 10s for a reply", fname=fname)
-        socket.recv_serialized(deserialize)  # Needed because of socket type
+        socket.recv_serialized(_deserialize)  # Needed because of socket type
 
 
 def _get_log_entry(runner: AsyncRunner, npoints_start: int) -> Dict[str, Any]:

--- a/adaptive_scheduler/client_support.py
+++ b/adaptive_scheduler/client_support.py
@@ -60,10 +60,11 @@ def get_learner(
         "trying to get learner", job_id=job_id, log_fname=log_fname, job_name=job_name
     )
     with ctx.socket(zmq.REQ) as socket:
+        socket.setsockopt(zmq.LINGER, 0)
         socket.connect(url)
-        socket.send_pyobj(("start", job_id, log_fname, job_name))
+        socket.send_pyobj(dill.dumps(("start", job_id, log_fname, job_name)))
         log.info(f"sent start signal, timeout after 10s.")
-        socket.setsockopt(zmq.RCVTIMEO, 10_000)  # timeout after 10s
+        socket.setsockopt(zmq.RCVTIMEO, 20_000)  # timeout after 10s
         reply = dill.loads(socket.recv_pyobj())
         log.info("got reply", reply=str(reply))
         if reply is None:

--- a/adaptive_scheduler/client_support.py
+++ b/adaptive_scheduler/client_support.py
@@ -5,11 +5,10 @@ import socket
 from contextlib import suppress
 from typing import Any, Dict, List, Tuple, Union
 
-import adaptive
 import psutil
 import structlog
 import zmq
-from adaptive import AsyncRunner
+from adaptive import AsyncRunner, BaseLearner
 
 from adaptive_scheduler.utils import (
     _deserialize,
@@ -40,7 +39,7 @@ def _add_log_file_handler(log_fname):
 
 def get_learner(
     url: str, log_fname: str, job_id: str, job_name: str,
-) -> Tuple[adaptive.BaseLearner, Union[str, List[str]]]:
+) -> Tuple[BaseLearner, Union[str, List[str]]]:
     """Get a learner from the database running at `url` and this learner's
     process will be logged in `log_fname` and running under `job_id`.
 

--- a/adaptive_scheduler/client_support.py
+++ b/adaptive_scheduler/client_support.py
@@ -71,8 +71,8 @@ def get_learner(
         socket.setsockopt(zmq.LINGER, 0)
         socket.connect(url)
         socket.send_serialized(("start", job_id, log_fname, job_name), serialize)
-        log.info(f"sent start signal, timeout after 10s.")
-        socket.setsockopt(zmq.RCVTIMEO, 20_000)  # timeout after 10s
+        log.info(f"sent start signal, going to wait 60s for a reply.")
+        socket.setsockopt(zmq.RCVTIMEO, 60_000)  # timeout after 60s
         reply = socket.recv_serialized(deserialize)
         log.info("got reply", reply=str(reply))
         if reply is None:
@@ -107,7 +107,7 @@ def tell_done(url: str, fname: str) -> None:
         socket.connect(url)
         socket.send_serialized(("stop", fname), serialize)
         socket.setsockopt(zmq.RCVTIMEO, 10_000)  # timeout after 10s
-        log.info("sent stop signal, timeout after 10s", fname=fname)
+        log.info("sent stop signal, going to wait 10s for a reply", fname=fname)
         socket.recv_serialized(deserialize)  # Needed because of socket type
 
 

--- a/adaptive_scheduler/run_script.py.j2
+++ b/adaptive_scheduler/run_script.py.j2
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+# {{ run_script_fname }}, automatically generated
+# by `adaptive_scheduler.server_support._make_default_run_script()`.
+{% if executor_type == "dask-mpi" %}
+from dask_mpi import initialize
+initialize()
+{% endif %}
+import argparse
+from contextlib import suppress
+
+import adaptive
+import cloudpickle
+from adaptive_scheduler import client_support
+{%- if executor_type == "mpi4py" %}
+from mpi4py.futures import MPIPoolExecutor
+{% elif executor_type == "ipyparallel" %}
+from adaptive_scheduler.utils import connect_to_ipyparallel
+{% elif executor_type == "dask-mpi" %}
+from distributed import Client
+{% elif executor_type == "process-pool" %}
+from loky import get_reusable_executor
+{% endif %}
+if __name__ == "__main__":  # ← use this, see warning @ https://bit.ly/2HAk0GG
+
+    # parse arguments
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--profile", action="store", dest="profile", type=str)
+    parser.add_argument("--n", action="store", dest="n", type=int)
+    parser.add_argument("--log-fname", action="store", dest="log_fname", type=str)
+    parser.add_argument("--job-id", action="store", dest="job_id", type=str)
+    parser.add_argument("--name", action="store", dest="name", type=str)
+    args = parser.parse_args()
+
+    # the address of the "database manager"
+    url = "{{ url }}"
+
+    # ask the database for a learner that we can run which we log in `args.log_fname`
+    learner, fname = client_support.get_learner(
+        url, args.log_fname, args.job_id, args.name
+    )
+
+    # load the data
+    with suppress(Exception):
+        learner.load(fname)
+
+    # connect to the executor
+    {%- if executor_type == "mpi4py" %}
+    executor = MPIPoolExecutor()
+    {% elif executor_type == "ipyparallel" %}
+    executor = connect_to_ipyparallel(profile=args.profile, n=args.n)
+    {% elif executor_type == "dask-mpi" %}
+    executor = Client()
+    {% elif executor_type == "process-pool" %}
+    executor = get_reusable_executor(max_workers=args.n)
+    {% endif %}
+    # this is serialized by cloudpickle.dumps
+    runner_kwargs = cloudpickle.loads(
+        {{ serialized_runner_kwargs }}
+    )
+
+    # run until `some_goal` is reached with an `MPIPoolExecutor`
+    runner = adaptive.Runner(learner, executor=executor, **runner_kwargs)
+
+    # periodically save the data (in case the job dies)
+    runner.start_periodic_saving(dict(fname=fname), interval={{ save_interval }})
+
+    # log progress info in the job output script, optional
+    client_support.log_info(runner, interval={{ log_interval }})
+
+    # block until runner goal reached
+    runner.ioloop.run_until_complete(runner.task)
+
+    # save once more after the runner is done
+    learner.save(fname)
+
+    # tell the database that this learner has reached its goal
+    client_support.tell_done(url, fname)
+
+    # log once more after the runner is done
+    client_support.log_info(runner, interval=0)

--- a/adaptive_scheduler/run_script.py.j2
+++ b/adaptive_scheduler/run_script.py.j2
@@ -12,7 +12,10 @@ import adaptive
 import cloudpickle
 from adaptive_scheduler import client_support
 {%- if executor_type == "mpi4py" %}
+import cloudpickle
+from mpi4py import MPI
 from mpi4py.futures import MPIPoolExecutor
+MPI.pickle.__init__(cloudpickle.dumps, cloudpickle.loads)
 {% elif executor_type == "ipyparallel" %}
 from adaptive_scheduler.utils import connect_to_ipyparallel
 {% elif executor_type == "dask-mpi" %}

--- a/adaptive_scheduler/server_support.py
+++ b/adaptive_scheduler/server_support.py
@@ -538,8 +538,8 @@ def _make_default_run_script(
         import_line = "from distributed import Client"
         executor_line = "Client()"
     elif executor_type == "process-pool":
-        import_line = "from concurrent.futures import ProcessPoolExecutor"
-        executor_line = "ProcessPoolExecutor(max_workers=args.n)"
+        import_line = "from loky import get_reusable_executor"
+        executor_line = "get_reusable_executor(max_workers=args.n)"
     else:
         raise NotImplementedError(
             "Use 'ipyparallel', 'dask-mpi', 'mpi4py' or 'process-pool'."

--- a/adaptive_scheduler/server_support.py
+++ b/adaptive_scheduler/server_support.py
@@ -235,6 +235,8 @@ class DatabaseManager(_BaseManager):
                 kwargs = dict(job_id=job_id, log_fname=log_fname, job_name=job_name)
                 # give the worker a job and send back the fname to the worker
                 fname = self._start_request(**kwargs)
+                if fname is None:
+                    raise RuntimeError("No more learners to run in the database.")
                 learner = next(
                     l
                     for l, f in zip(self.learners, self.fnames)

--- a/adaptive_scheduler/server_support.py
+++ b/adaptive_scheduler/server_support.py
@@ -111,7 +111,7 @@ class DatabaseManager(_BaseManager):
         scheduler: BaseScheduler,
         db_fname: str,
         learners: List[adaptive.BaseLearner],
-        fnames: List[str],
+        fnames: Union[List[str], List[List[str]]],
         overwrite_db: bool = True,
     ):
         super().__init__()
@@ -119,7 +119,7 @@ class DatabaseManager(_BaseManager):
         self.scheduler = scheduler
         self.db_fname = db_fname
         self.learners = learners
-        self.fnames = list(map(str, fnames))  # convert from pathlib.Path
+        self.fnames = fnames
         self.overwrite_db = overwrite_db
 
         self.defaults = dict(
@@ -784,7 +784,7 @@ class RunManager(_BaseManager):
         self,
         scheduler: BaseScheduler,
         learners: List[adaptive.BaseLearner],
-        fnames: List[Union[str, Path]],
+        fnames: List[str],
         goal: Union[Callable[[adaptive.BaseLearner], bool], None] = None,
         check_goal_on_start: bool = True,
         runner_kwargs: Optional[dict] = None,
@@ -826,6 +826,7 @@ class RunManager(_BaseManager):
         # Set on init
         self.learners = learners
         self.fnames = fnames
+
         self.job_names = [f"{self.job_name}-{i}" for i in range(len(self.learners))]
         self.url = url or get_allowed_url()
         self.database_manager = DatabaseManager(
@@ -872,7 +873,7 @@ class RunManager(_BaseManager):
             # Only works after the `database_manager` has started.
             for fname, learner in zip(self.fnames, self.learners):
                 if self.goal(learner):
-                    self.database_manager._stop_request(str(fname))
+                    self.database_manager._stop_request(fname)
         self.job_manager.start()
         if self.kill_manager:
             self.kill_manager.start()

--- a/adaptive_scheduler/server_support.py
+++ b/adaptive_scheduler/server_support.py
@@ -832,6 +832,12 @@ class RunManager(_BaseManager):
         self.learners = learners
         self.fnames = fnames
 
+        if isinstance(self.fnames[0], (list, tuple)):
+            # For a BalancingLearner
+            assert isinstance(self.fnames[0][0], str)
+        else:
+            assert isinstance(self.fnames[0], str)
+
         self.job_names = [f"{self.job_name}-{i}" for i in range(len(self.learners))]
         self.url = url or get_allowed_url()
         self.database_manager = DatabaseManager(

--- a/adaptive_scheduler/server_support.py
+++ b/adaptive_scheduler/server_support.py
@@ -207,10 +207,14 @@ class DatabaseManager(_BaseManager):
             )
         return entry["fname"]
 
-    def _stop_request(self, fname: str) -> None:
+    def _stop_request(self, fname: Union[str, List[str]]) -> None:
+        fname = maybe_lst(fname)  # if a BalancingLearner
         Entry = Query()
         with TinyDB(self.db_fname) as db:
             reset = dict(job_id=None, is_done=True, job_name=None)
+            assert (
+                db.get(Entry.fname == fname) is not None
+            )  # make sure the entry exists
             db.update(reset, Entry.fname == fname)
 
     def _dispatch(self, request: Tuple[str, ...]) -> Union[str, Exception, None]:

--- a/adaptive_scheduler/server_support.py
+++ b/adaptive_scheduler/server_support.py
@@ -26,12 +26,12 @@ from tinydb import Query, TinyDB
 
 from adaptive_scheduler.scheduler import BaseScheduler
 from adaptive_scheduler.utils import (
+    _deserialize,
     _progress,
     _remove_or_move_files,
-    deserialize,
+    _serialize,
     load_parallel,
     maybe_lst,
-    serialize,
 )
 from adaptive_scheduler.widgets import log_explorer
 
@@ -262,9 +262,9 @@ class DatabaseManager(_BaseManager):
         socket.bind(self.url)
         try:
             while True:
-                self._last_request = await socket.recv_serialized(deserialize)
+                self._last_request = await socket.recv_serialized(_deserialize)
                 self._last_reply = self._dispatch(self._last_request)
-                await socket.send_serialized(self._last_reply, serialize)
+                await socket.send_serialized(self._last_reply, _serialize)
         finally:
             socket.close()
 

--- a/adaptive_scheduler/utils.py
+++ b/adaptive_scheduler/utils.py
@@ -16,8 +16,8 @@ from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
 
 import adaptive
-import numpy as np
 import cloudpickle
+import numpy as np
 import toolz
 from adaptive.notebook_integration import in_ipynb
 from ipyparallel import Client
@@ -262,7 +262,7 @@ def combo2fname(
     folder: Optional[Union[str, Path]] = None,
     ext: Optional[str] = ".pickle",
     sig_figs: int = 8,
-) -> Path:
+) -> str:
     """Converts a dict into a human readable filename.
 
     Improved version of `combo_to_fname`."""
@@ -270,7 +270,7 @@ def combo2fname(
     fname = Path("__".join(name_parts) + ext)
     if folder is None:
         return fname
-    return folder / fname
+    return str(folder / fname)
 
 
 def add_constant_to_fname(

--- a/adaptive_scheduler/utils.py
+++ b/adaptive_scheduler/utils.py
@@ -490,3 +490,10 @@ def log_exception(log, msg, exception):
         raise exception
     except Exception:
         log.exception(msg, exc_info=True)
+
+
+def maybe_lst(fname: Union[List[str], str]):
+    if isinstance(fname, tuple):
+        # TinyDB converts tuples to lists
+        fname = list(fname)
+    return fname

--- a/adaptive_scheduler/utils.py
+++ b/adaptive_scheduler/utils.py
@@ -17,6 +17,7 @@ from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
 
 import adaptive
 import numpy as np
+import cloudpickle
 import toolz
 from adaptive.notebook_integration import in_ipynb
 from ipyparallel import Client
@@ -497,3 +498,11 @@ def maybe_lst(fname: Union[List[str], str]):
         # TinyDB converts tuples to lists
         fname = list(fname)
     return fname
+
+
+def serialize(msg):
+    return [cloudpickle.dumps(msg)]
+
+
+def deserialize(frames):
+    return cloudpickle.loads(frames[0])

--- a/adaptive_scheduler/utils.py
+++ b/adaptive_scheduler/utils.py
@@ -227,6 +227,29 @@ def combine_sequence_learners(
     return big_learner
 
 
+def copy_from_sequence_learner(
+    learner_from: adaptive.SequenceLearner, learner_to: adaptive.SequenceLearner
+) -> None:
+    """Convinience function to copy the data from a `~adaptive.SequenceLearner`
+    into a different `~adaptive.SequenceLearner`.
+
+    Parameters
+    ----------
+    learner_from : adaptive.SequenceLearner
+        Learner to take the data from.
+    learner_to : adaptive.SequenceLearner
+        Learner to tell the data to.
+    """
+    mapping = {
+        hash_anything(learner_from.sequence[i]): v for i, v in learner_from.data.items()
+    }
+    for i, key in enumerate(learner_to.sequence):
+        hsh = hash_anything(key)
+        if hsh in mapping:
+            v = mapping[hsh]
+            learner_to.tell((i, key), v)
+
+
 def _get_npoints(learner: adaptive.BaseLearner) -> Optional[int]:
     with suppress(AttributeError):
         return learner.npoints

--- a/adaptive_scheduler/utils.py
+++ b/adaptive_scheduler/utils.py
@@ -110,7 +110,7 @@ def split_in_balancing_learners(
 
 def split_sequence_learner(
     big_learner, n_learners: int, folder: Union[str, Path] = "",
-) -> Tuple[List[adaptive.SequenceLearner], List[Path]]:
+) -> Tuple[List[adaptive.SequenceLearner], List[str]]:
     r"""Split a sinlge `~adaptive.SequenceLearner` into
     mutiple `adaptive.SequenceLearner`\s (with the data loaded) and fnames.
 
@@ -130,7 +130,7 @@ def split_sequence_learner(
     new_learners : List[adaptive.SequenceLearner]
         List of `~adaptive.SequenceLearner`\s.
     new_fnames : List[Path]
-        List of `pathlib.Path`\s based on a hash of the sequence.
+        List of str based on a hash of the sequence.
     """
     new_learners, new_fnames = split_sequence_in_sequence_learners(
         function=big_learner._original_function,
@@ -156,7 +156,7 @@ def split_sequence_in_sequence_learners(
     sequence: Sequence[Any],
     n_learners: int,
     folder: Union[str, Path] = "",
-) -> Tuple[List[adaptive.SequenceLearner], List[Path]]:
+) -> Tuple[List[adaptive.SequenceLearner], List[str]]:
     r"""Split a sequenceinto `adaptive.SequenceLearner`\s and fnames.
 
     Parameters
@@ -175,7 +175,7 @@ def split_sequence_in_sequence_learners(
     new_learners : List[adaptive.SequenceLearner]
         List of `~adaptive.SequenceLearner`\s.
     new_fnames : List[Path]
-        List of `pathlib.Path`\s based on a hash of the sequence.
+        List of str based on a hash of the sequence.
     """
     folder = Path(folder)
     new_learners = []
@@ -185,7 +185,7 @@ def split_sequence_in_sequence_learners(
         new_learners.append(learner)
         hsh = hash_anything((sequence_part[0], len(sequence_part)))
         fname = folder / f"{hsh}.pickle"
-        new_fnames.append(fname)
+        new_fnames.append(str(fname))
     return new_learners, new_fnames
 
 

--- a/adaptive_scheduler/utils.py
+++ b/adaptive_scheduler/utils.py
@@ -523,9 +523,9 @@ def maybe_lst(fname: Union[List[str], str]):
     return fname
 
 
-def serialize(msg):
+def _serialize(msg):
     return [cloudpickle.dumps(msg)]
 
 
-def deserialize(frames):
+def _deserialize(frames):
     return cloudpickle.loads(frames[0])

--- a/adaptive_scheduler/widgets.py
+++ b/adaptive_scheduler/widgets.py
@@ -35,7 +35,7 @@ def log_explorer(run_manager) -> VBox:  # noqa: C901
             current_value = dropdown.value
             fnames = _get_fnames(run_manager, checkbox.value)
             dropdown.options = fnames
-            with suppress(StopIteration):
+            with suppress(Exception):
                 dropdown.value = current_value
             dropdown.disabled = not fnames
 

--- a/adaptive_scheduler/widgets.py
+++ b/adaptive_scheduler/widgets.py
@@ -10,6 +10,8 @@ def _get_fnames(run_manager, only_running: bool) -> List[Path]:
     if only_running:
         fnames = []
         for entry in run_manager.database_manager.as_dicts():
+            if entry["is_done"]:
+                continue
             if entry["log_fname"] is not None:
                 fnames.append(entry["log_fname"])
             fnames += entry["output_logs"]

--- a/docs/source/FAQ.rst
+++ b/docs/source/FAQ.rst
@@ -14,8 +14,6 @@ Q: What if I have more learners than cores?
 
 .. code-block:: python
 
-    %%writefile learners_file.py
-
     from functools import partial
 
     import adaptive
@@ -90,8 +88,9 @@ For example:
     )
 
     run_manager = adaptive_scheduler.server_support.RunManager(
-        learners_file="learners_file.py",
         scheduler=scheduler,
+        learners=learners,
+        fnames=fnames,
 
     )
     run_manager.start()

--- a/environment.yml
+++ b/environment.yml
@@ -9,9 +9,11 @@ dependencies:
   - cloudpickle
   - dill
   - ipyparallel
+  - jinja2
   - loky
   - mpich
   - mpi4py
+  - numpy
   - pandas
   - psutil
   - pyzmq

--- a/environment.yml
+++ b/environment.yml
@@ -6,8 +6,10 @@ channels:
 dependencies:
   - python
   - adaptive
+  - cloudpickle
   - dill
   - ipyparallel
+  - loky
   - mpich
   - mpi4py
   - pandas

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
 
 dependencies:
   - python
-  - adaptive
+  - adaptive >=0.11
   - cloudpickle
   - dill
   - ipyparallel

--- a/example.ipynb
+++ b/example.ipynb
@@ -28,10 +28,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%writefile learners_file.py\n",
+    "from functools import partial\n",
     "\n",
     "import adaptive\n",
-    "from functools import partial\n",
     "\n",
     "\n",
     "def h(x, width=0.01, offset=0):\n",
@@ -63,7 +62,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Step 2: run the `learners_file`\n",
+    "# Step 2: run the `learners`\n",
     "\n",
     "After defining the `learners` and `fnames` in an file (above) we can start to run these learners.\n",
     "\n",
@@ -85,17 +84,19 @@
    "source": [
     "import adaptive_scheduler\n",
     "\n",
+    "\n",
     "def goal(learner):\n",
     "    return learner.npoints > 200\n",
     "\n",
+    "\n",
     "scheduler = adaptive_scheduler.scheduler.DefaultScheduler(\n",
-    "    cores=10,\n",
-    "    executor_type=\"ipyparallel\",\n",
+    "    cores=10, executor_type=\"ipyparallel\",\n",
     ")  # PBS or SLURM\n",
     "\n",
     "run_manager = adaptive_scheduler.server_support.RunManager(\n",
     "    scheduler=scheduler,\n",
-    "    learners_file=\"learners_file.py\",\n",
+    "    learners=learners,\n",
+    "    fnames=fnames,\n",
     "    goal=goal,\n",
     "    log_interval=30,\n",
     "    save_interval=30,\n",
@@ -111,6 +112,7 @@
    "source": [
     "# See the current queue with\n",
     "import pandas as pd\n",
+    "\n",
     "queue = scheduler.queue()\n",
     "df = pd.DataFrame(queue).transpose()\n",
     "df.head()"
@@ -148,10 +150,9 @@
    "source": [
     "# After the calculation started and some data has been saved, we can display the learners\n",
     "import adaptive\n",
+    "\n",
     "adaptive.notebook_extension()\n",
     "\n",
-    "learners = run_manager.learners_module.learners  # or `from learners_file import learners`\n",
-    "combos = run_manager.learners_module.combos  # or `from learners_file import combos`\n",
     "run_manager.load_learners()\n",
     "learner = adaptive.BalancingLearner(learners, cdims=combos)\n",
     "learner.plot()"
@@ -173,8 +174,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%writefile learners_file_sequence.py\n",
-    "\n",
     "import numpy as np\n",
     "\n",
     "from adaptive import SequenceLearner\n",
@@ -195,7 +194,7 @@
     "\n",
     "# We have only one learner so one fname\n",
     "learners = [SequenceLearner(g, sequence=xyzs)]\n",
-    "fnames = ['data/xyzs']"
+    "fnames = [\"data/xyzs\"]"
    ]
   },
   {
@@ -206,17 +205,19 @@
    "source": [
     "import adaptive_scheduler\n",
     "\n",
+    "\n",
     "def goal(learner):\n",
     "    return learner.done()\n",
     "\n",
+    "\n",
     "scheduler = adaptive_scheduler.scheduler.DefaultScheduler(\n",
-    "    cores=10,\n",
-    "    executor_type=\"ipyparallel\",\n",
+    "    cores=10, executor_type=\"ipyparallel\",\n",
     ")  # PBS or SLURM\n",
     "\n",
     "run_manager2 = adaptive_scheduler.server_support.RunManager(\n",
     "    scheduler=scheduler,\n",
-    "    learners_file=\"learners_file_sequence.py\",\n",
+    "    learners=learners,\n",
+    "    fnames=fnames,\n",
     "    goal=goal,\n",
     "    log_interval=30,\n",
     "    save_interval=30,\n",
@@ -231,12 +232,12 @@
    "outputs": [],
    "source": [
     "run_manager2.load_learners()\n",
-    "learner = run_manager2.learners_module.learners[0]\n",
+    "learner = learners[0]\n",
     "try:\n",
     "    result = learner.result()\n",
     "    print(result)\n",
     "except:\n",
-    "    print('`learner.result()` is only available when all values are calculated.')\n",
+    "    print(\"`learner.result()` is only available when all values are calculated.\")\n",
     "    partial_data = learner.data\n",
     "    print(partial_data)"
    ]
@@ -255,17 +256,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%writefile learners_file_sequence2.py\n",
-    "\n",
     "import numpy as np\n",
     "\n",
     "from adaptive import SequenceLearner\n",
-    "from adaptive_scheduler.utils import split, combo_to_fname\n",
+    "from adaptive_scheduler.utils import split, combo2fname\n",
     "from adaptive.utils import named_product\n",
     "\n",
     "\n",
     "def g(combo):\n",
-    "    x, y, z = combo['x'], combo['y'], combo['z']\n",
+    "    x, y, z = combo[\"x\"], combo[\"y\"], combo[\"z\"]\n",
     "\n",
     "    for _ in range(5):  # Burn some CPU time just because\n",
     "        np.linalg.eig(np.random.rand(1000, 1000))\n",
@@ -279,14 +278,19 @@
     "\n",
     "# We could run this as 1 job with N nodes, but we can also split it up in multiple jobs.\n",
     "# This is desireable when you don't want to run a single job with 300 nodes for example.\n",
+    "# Note that \n",
+    "# `adaptive_scheduler.utils.split_sequence_in_sequence_learners(g, combos, 100, \"data\")`\n",
+    "# does the same!\n",
+    "\n",
     "njobs = 100\n",
     "split_combos = list(split(combos, njobs))\n",
     "\n",
-    "print(f\"Length of split_combos: {len(split_combos)} and length of split_combos[0]: {len(split_combos[0])}.\")\n",
+    "print(\n",
+    "    f\"Length of split_combos: {len(split_combos)} and length of split_combos[0]: {len(split_combos[0])}.\"\n",
+    ")\n",
     "\n",
-    "learners, fnames = [], []\n",
     "learners = [SequenceLearner(g, combos_part) for combos_part in split_combos]\n",
-    "fnames = [combo_to_fname(combos_part[0], folder=\"data\") for combos_part in split_combos]"
+    "fnames = [combo2fname(combos_part[0], folder=\"data\") for combos_part in split_combos]"
    ]
   },
   {
@@ -310,10 +314,13 @@
     "def goal(learner):\n",
     "    return learner.done()  # the standard goal for a SequenceLearner\n",
     "\n",
-    "extra_scheduler = [\"--exclusive\", \"--time=24:00:00\"] if DefaultScheduler is SLURM else []\n",
+    "\n",
+    "extra_scheduler = (\n",
+    "    [\"--exclusive\", \"--time=24:00:00\"] if DefaultScheduler is SLURM else []\n",
+    ")\n",
     "\n",
     "scheduler = adaptive_scheduler.scheduler.DefaultScheduler(\n",
-    "    cores=10, \n",
+    "    cores=10,\n",
     "    executor_type=\"ipyparallel\",\n",
     "    extra_scheduler=extra_scheduler,\n",
     "    extra_env_vars=[\"PYTHONPATH='my_dir:$PYTHONPATH'\"],\n",
@@ -323,12 +330,13 @@
     "\n",
     "run_manager3 = adaptive_scheduler.server_support.RunManager(\n",
     "    scheduler,\n",
+    "    learners=learners,\n",
+    "    fnames=fnames,\n",
     "    goal=goal,\n",
     "    log_interval=10,\n",
     "    save_interval=30,\n",
     "    runner_kwargs=dict(retries=5, raise_if_retries_exceeded=False),\n",
     "    kill_on_error=\"srun: error:\",  # cancel a job if this is inside a log\n",
-    "    learners_file=\"learners_file_sequence2.py\",  # the file that has `learners` and `fnames`\n",
     "    job_name=\"example-sequence\",  # this is used to generate unqiue job names\n",
     "    db_fname=\"example-sequence.json\",  # the database keeps track of job_id <-> (learner, is_done)\n",
     "    start_job_manager_kwargs=dict(\n",
@@ -364,8 +372,9 @@
    "outputs": [],
    "source": [
     "run_manager3.load_learners()  # load the data into the learners\n",
-    "learners = run_manager3.learners_module.learners\n",
-    "result = sum([l.result() for l in learners], [])  # combine all learner's result into 1 list"
+    "result = sum(\n",
+    "    [l.result() for l in learners], []\n",
+    ")  # combine all learner's result into 1 list"
    ]
   }
  ],
@@ -376,5 +385,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }

--- a/example.ipynb
+++ b/example.ipynb
@@ -94,12 +94,7 @@
     ")  # PBS or SLURM\n",
     "\n",
     "run_manager = adaptive_scheduler.server_support.RunManager(\n",
-    "    scheduler=scheduler,\n",
-    "    learners=learners,\n",
-    "    fnames=fnames,\n",
-    "    goal=goal,\n",
-    "    log_interval=30,\n",
-    "    save_interval=30,\n",
+    "    scheduler, learners, fnames, goal=goal, log_interval=30, save_interval=30,\n",
     ")\n",
     "run_manager.start()"
    ]
@@ -215,12 +210,7 @@
     ")  # PBS or SLURM\n",
     "\n",
     "run_manager2 = adaptive_scheduler.server_support.RunManager(\n",
-    "    scheduler=scheduler,\n",
-    "    learners=learners,\n",
-    "    fnames=fnames,\n",
-    "    goal=goal,\n",
-    "    log_interval=30,\n",
-    "    save_interval=30,\n",
+    "    scheduler, learners, fnames, goal=goal, log_interval=30, save_interval=30,\n",
     ")\n",
     "run_manager2.start()"
    ]
@@ -330,8 +320,8 @@
     "\n",
     "run_manager3 = adaptive_scheduler.server_support.RunManager(\n",
     "    scheduler,\n",
-    "    learners=learners,\n",
-    "    fnames=fnames,\n",
+    "    learners,\n",
+    "    fnames,\n",
     "    goal=goal,\n",
     "    log_interval=10,\n",
     "    save_interval=30,\n",

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ adaptive
 cloudpickle
 dill
 ipyparallel
+jinja2
 loky
 mpi4py
 numpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
 adaptive
+cloudpickle
 dill
 ipyparallel
+loky
 mpi4py
 numpy
 pandas

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-adaptive
+adaptive>=0.11
 cloudpickle
 dill
 ipyparallel


### PR DESCRIPTION
This is currently blocked by 
* ~~https://github.com/python-adaptive/adaptive/pull/263~~
* ~~https://github.com/python-adaptive/adaptive/pull/264~~


With the code of this PR one can do:
```python
run_manager = adaptive_scheduler.server_support.RunManager(
    scheduler=scheduler,
    learners=learners,
    fnames=fnames,
    goal=goal,
)
```

- [x] For the mpi4py executor use `MPI.pickle.__init__(my_dumps, my_loads)` https://bitbucket.org/mpi4py/mpi4py/issues/82/pickling-no-longer-customizable
- [x] release Adaptive 0.11