### PR TITLE
Ensure consistent encodings for input/output files

### DIFF
--- a/adaptive_scheduler/_version.py
+++ b/adaptive_scheduler/_version.py
@@ -180,7 +180,7 @@ def _write_version(fname):
         os.remove(fname)
     except OSError:
         pass
-    with open(fname, "w") as f:
+    with open(fname, "w", encoding="utf-8") as f:
         f.write(
             "# This file has been created by setup.py.\n"
             "version = '{}'\n".format(__version__)

--- a/adaptive_scheduler/scheduler.py
+++ b/adaptive_scheduler/scheduler.py
@@ -267,7 +267,7 @@ class BaseScheduler(metaclass=_RequireAttrsABCMeta):
         return str(self._extra_script) or ""
 
     def write_job_script(self, name: str) -> None:
-        with open(self.batch_fname(name), "w") as f:
+        with open(self.batch_fname(name), "w", encoding="utf-8") as f:
             job_script = self.job_script()
             f.write(job_script)
 

--- a/adaptive_scheduler/server_support.py
+++ b/adaptive_scheduler/server_support.py
@@ -439,7 +439,7 @@ def logs_with_string_or_condition(
     def file_has_error(fname):
         if not os.path.exists(fname):
             return False
-        with open(fname) as f:
+        with open(fname, encoding="utf-8") as f:
             lines = f.readlines()
         return has_error(lines)
 
@@ -587,7 +587,7 @@ def _make_default_run_script(
 
 def _get_infos(fname: str, only_last: bool = True) -> List[str]:
     status_lines: List[str] = []
-    with open(fname) as f:
+    with open(fname, encoding="utf-8") as f:
         lines = f.readlines()
         for line in reversed(lines):
             with suppress(Exception):

--- a/adaptive_scheduler/widgets.py
+++ b/adaptive_scheduler/widgets.py
@@ -69,9 +69,9 @@ def _failed_job_logs(fnames, run_manager, only_running):
     return failed
 
 
-def _files_that_contain(fnames, text):
-    def contains(fname, text):
-        with fname.open() as f:
+def _files_that_contain(fnames: list[Path], text: str):
+    def contains(fname: Path, text: str):
+        with fname.open("r", encoding="utf-8") as f:
             for line in f:
                 if text in line:
                     return True
@@ -148,7 +148,7 @@ def _sort_fnames(sort_by, run_manager, fnames):
 
 def _read_file(fname: Path) -> str:
     try:
-        with fname.open() as f:
+        with fname.open("r", encoding="utf-8") as f:
             return "".join(f.readlines())
     except UnicodeDecodeError:
         return f"Could not decode file ({fname})!"


### PR DESCRIPTION
Recently I encountered a number of unicode decoding errors when running on a CentOS 7 backed cluster. Running an editable install with the included changes cleaned up all of the file reading errors that I was encountering.