### PR TITLE
Allow to wait for a RunManger to complete before starting a new run

### DIFF
--- a/adaptive_scheduler/__init__.py
+++ b/adaptive_scheduler/__init__.py
@@ -1,16 +1,17 @@
 from adaptive_scheduler import client_support, scheduler, server_support, utils
 from adaptive_scheduler._version import __version__
 from adaptive_scheduler.scheduler import PBS, SLURM
-from adaptive_scheduler.server_support import RunManager, slurm_run
+from adaptive_scheduler.server_support import RunManager, slurm_run, start_one_by_one
 
 __all__ = [
+    "__version__",
     "client_support",
     "PBS",
     "RunManager",
     "scheduler",
     "server_support",
-    "SLURM",
-    "utils",
     "slurm_run",
-    "__version__",
+    "SLURM",
+    "start_one_by_one",
+    "utils",
 ]

--- a/adaptive_scheduler/server_support.py
+++ b/adaptive_scheduler/server_support.py
@@ -1321,6 +1321,8 @@ def start_one_by_one(*run_managers) -> tuple[asyncio.Task, list[asyncio.Task]]:
     """Start a list of RunManagers after each other."""
     if len({r.name for r in run_managers}) != len(run_managers):
         raise ValueError("All run managers must have a unique name.")
+    if len({r.database_manager.db_fname for r in run_managers}) != len(run_managers):
+        raise ValueError("All run managers must have a unique database filename.")
     tasks = [
         _start_after(run_managers[i], run_managers[i + 1])
         for i in range(len(run_managers) - 1)

--- a/adaptive_scheduler/server_support.py
+++ b/adaptive_scheduler/server_support.py
@@ -1004,7 +1004,8 @@ class RunManager(_BaseManager):
         """Start the RunManager and optionally wait for another RunManager to finish."""
         if wait_for is not None:
             self._start_one_by_one_task = start_one_by_one(wait_for, self)
-        super().start()
+        else:
+            super().start()
 
     async def _manage(self) -> None:
         await self.job_manager.task

--- a/adaptive_scheduler/server_support.py
+++ b/adaptive_scheduler/server_support.py
@@ -1323,7 +1323,19 @@ def _start_after(manager_first, manager_second) -> asyncio.Task:
 
 
 def start_one_by_one(*run_managers) -> tuple[asyncio.Task, list[asyncio.Task]]:
-    """Start a list of RunManagers after each other."""
+    """Start a list of RunManagers after each other.
+
+    Parameters
+    ----------
+    run_managers : list[RunManager]
+        A list of RunManagers.
+
+    Returns
+    -------
+    tuple[asyncio.Task, list[asyncio.Task]]
+        The first element is the grouped task that starts all RunManagers.
+        The second element is a list of tasks that start each RunManager.
+    """
     uniques = ["job_name", "db_fname"]
     for u in uniques:
         if len({getattr(r, u) for r in run_managers}) != len(run_managers):

--- a/adaptive_scheduler/server_support.py
+++ b/adaptive_scheduler/server_support.py
@@ -1314,8 +1314,6 @@ async def _wait_for(manager_first: RunManager, manager_second: RunManager):
 
 
 def _start_after(manager_first, manager_second) -> asyncio.Task:
-    if not manager_first.is_started:
-        manager_first.start()
     if manager_second.is_started:
         raise ValueError("The second manager must not be started yet.")
     coro = _wait_for(manager_first, manager_second)
@@ -1341,7 +1339,7 @@ def start_one_by_one(*run_managers) -> tuple[asyncio.Task, list[asyncio.Task]]:
         if len({getattr(r, u) for r in run_managers}) != len(run_managers):
             raise ValueError(
                 f"All `RunManager`s must have a unique {u}."
-                "If using `slurm_run` these are controlled through the `name` argument."
+                " If using `slurm_run` these are controlled through the `name` argument."
             )
 
     tasks = [

--- a/adaptive_scheduler/server_support.py
+++ b/adaptive_scheduler/server_support.py
@@ -1331,7 +1331,7 @@ def _start_after(
     if manager_second.is_started:
         raise ValueError("The second manager must not be started yet.")
     coro = _wait_for_finished(manager_first, manager_second, goal, interval)
-    return manager_first.ioloop.create_task(coro)
+    return asyncio.create_task(coro)
 
 
 def start_one_by_one(

--- a/adaptive_scheduler/server_support.py
+++ b/adaptive_scheduler/server_support.py
@@ -1306,13 +1306,15 @@ def slurm_run(
 
 
 async def _wait_for(manager_first: RunManager, manager_second: RunManager):
-    if not manager_first.is_started:
-        manager_first.start()
     await manager_first.task
     manager_second.start()
 
 
 def _start_after(manager_first, manager_second) -> asyncio.Task:
+    if not manager_first.is_started:
+        manager_first.start()
+    if manager_second.is_started:
+        raise ValueError("The second manager must not be started yet.")
     coro = _wait_for(manager_first, manager_second)
     return manager_first.ioloop.create_task(coro)
 

--- a/adaptive_scheduler/server_support.py
+++ b/adaptive_scheduler/server_support.py
@@ -1380,7 +1380,10 @@ def start_one_by_one(
     >>> # Start second when the first RunManager has more than 1000 points.
     >>> def start_goal(run_manager):
     ...     df = run_manager.parse_log_files()
-    ...     return df.get("npoints", 0) > 1000
+    ...     npoints = df.get("npoints")
+    ...     if npoints is None:
+    ...         return False
+    ...     return npoints.sum() > 300
     >>> tasks = adaptive_scheduler.start_one_by_one(
     ...     manager_1,
     ...     manager_2,

--- a/adaptive_scheduler/server_support.py
+++ b/adaptive_scheduler/server_support.py
@@ -1006,6 +1006,7 @@ class RunManager(_BaseManager):
             self._start_one_by_one_task = start_one_by_one(wait_for, self)
         else:
             super().start()
+        return self
 
     async def _manage(self) -> None:
         await self.job_manager.task

--- a/adaptive_scheduler/server_support.py
+++ b/adaptive_scheduler/server_support.py
@@ -1383,7 +1383,7 @@ def start_one_by_one(
     ...     npoints = df.get("npoints")
     ...     if npoints is None:
     ...         return False
-    ...     return npoints.sum() > 300
+    ...     return npoints.sum() > 1000
     >>> tasks = adaptive_scheduler.start_one_by_one(
     ...     manager_1,
     ...     manager_2,

--- a/adaptive_scheduler/server_support.py
+++ b/adaptive_scheduler/server_support.py
@@ -1359,6 +1359,34 @@ def start_one_by_one(
     tuple[asyncio.Task, list[asyncio.Task]]
         The first element is the grouped task that starts all RunManagers.
         The second element is a list of tasks that start each RunManager.
+
+    Examples
+    --------
+    >>> manager_1 = adaptive_scheduler.slurm_run(
+    ...     learners[:5],
+    ...     fnames[:5],
+    ...     partition="hb120rsv2-low",
+    ...     goal=0.01,
+    ...     name="first",
+    ... )
+    >>> manager_1.start()
+    >>> manager_2 = adaptive_scheduler.slurm_run(
+    ...     learners[5:],
+    ...     fnames[5:],
+    ...     partition="hb120rsv2-low",
+    ...     goal=0.01,
+    ...     name="second",
+    ... )
+    >>> # Start second when the first RunManager has more than 1000 points.
+    >>> def start_goal(run_manager):
+    ...     df = run_manager.parse_log_files()
+    ...     return df.get("npoints", 0) > 1000
+    >>> tasks = adaptive_scheduler.start_one_by_one(
+    ...     manager_1,
+    ...     manager_2,
+    ...     goal=start_goal,
+    ... )
+
     """
     uniques = ["job_name", "db_fname"]
     for u in uniques:


### PR DESCRIPTION
Allows to do

```python
manager_1 = adaptive_scheduler.slurm_run(
    learners[:5],
    fnames[:5],
    partition="hb120rsv2-low",
    goal=0.01,
    name="first",
)
manager_1.start(wait_for=None) # None is the default
display(manager_1)

manager_2 = adaptive_scheduler.slurm_run(
    learners[5:-2],
    fnames[5:-2],
    partition="hb120rsv2-low",
    goal=0.01,
    name="second",
)
manager_2.start(wait_for=manager_1)
display(manager_2)

manager_3 = adaptive_scheduler.slurm_run(
    learners[-2:],
    fnames[-2:],
    partition="hb120rsv2-low",
    goal=0.01,
    name="third",
)
manager_3.start(wait_for=manager_2)
```