### PR TITLE
Place database file and batch scripts in 'folder' when invoking slurm_run

### DIFF
--- a/adaptive_scheduler/_scheduler/base_scheduler.py
+++ b/adaptive_scheduler/_scheduler/base_scheduler.py
@@ -53,6 +53,8 @@ class BaseScheduler(abc.ABC):
     extra_script : str, optional
         Extra script that will be executed after any environment variables are set,
         but before the main scheduler is run.
+    batch_folder : str, default: ""
+        The folder in which to put the batch files.
 
     Returns
     -------
@@ -77,11 +79,13 @@ class BaseScheduler(abc.ABC):
         extra_scheduler: list[str] | None = None,
         extra_env_vars: list[str] | None = None,
         extra_script: str | None = None,
+        batch_folder: str | Path = "",
     ) -> None:
         """Initialize the scheduler."""
         self.cores = cores
         self.python_executable = python_executable or sys.executable
         self.log_folder = log_folder
+        self.batch_folder = batch_folder
         self.mpiexec_executable = mpiexec_executable or "mpiexec"
         self.executor_type = executor_type
         self.num_threads = num_threads
@@ -137,7 +141,12 @@ class BaseScheduler(abc.ABC):
 
     def batch_fname(self, name: str) -> Path:
         """The filename of the job script."""
-        return Path(f"{name}{self.ext}")
+        if self.batch_folder:
+            batch_folder = Path(self.batch_folder)
+            batch_folder.mkdir(exist_ok=True)
+        else:
+            batch_folder = Path.cwd()
+        return batch_folder / f"{name}{self.ext}"
 
     @staticmethod
     def sanatize_job_id(job_id: str) -> str:

--- a/adaptive_scheduler/_scheduler/local.py
+++ b/adaptive_scheduler/_scheduler/local.py
@@ -37,6 +37,7 @@ class LocalMockScheduler(BaseScheduler):
         extra_scheduler: list[str] | None = None,
         extra_env_vars: list[str] | None = None,
         extra_script: str | None = None,
+        batch_folder: str | Path = "",
         # LocalMockScheduler specific
         mock_scheduler_kwargs: dict[str, Any] | None = None,
     ) -> None:
@@ -54,6 +55,7 @@ class LocalMockScheduler(BaseScheduler):
             extra_scheduler=extra_scheduler,
             extra_env_vars=extra_env_vars,
             extra_script=extra_script,
+            batch_folder=batch_folder,
         )
         # LocalMockScheduler specific
         self.mock_scheduler_kwargs = mock_scheduler_kwargs or {}

--- a/adaptive_scheduler/_scheduler/pbs.py
+++ b/adaptive_scheduler/_scheduler/pbs.py
@@ -46,6 +46,7 @@ class PBS(BaseScheduler):
         extra_scheduler: list[str] | None = None,
         extra_env_vars: list[str] | None = None,
         extra_script: str | None = None,
+        batch_folder: str | Path = "",
         # Extra PBS specific arguments
         cores_per_node: int | None = None,
     ) -> None:
@@ -60,6 +61,7 @@ class PBS(BaseScheduler):
             extra_scheduler=extra_scheduler,
             extra_env_vars=extra_env_vars,
             extra_script=extra_script,
+            batch_folder=batch_folder,
         )
         # PBS specific
         self.cores_per_node = cores_per_node

--- a/adaptive_scheduler/_scheduler/slurm.py
+++ b/adaptive_scheduler/_scheduler/slurm.py
@@ -82,6 +82,7 @@ class SLURM(BaseScheduler):
         extra_scheduler: list[str] | None = None,
         extra_env_vars: list[str] | None = None,
         extra_script: str | None = None,
+        batch_folder: str | Path = "",
     ) -> None:
         """Initialize the scheduler."""
         self._cores = cores
@@ -125,6 +126,7 @@ class SLURM(BaseScheduler):
             extra_scheduler=extra_scheduler,
             extra_env_vars=extra_env_vars,
             extra_script=extra_script,
+            batch_folder=batch_folder,
         )
         # SLURM specific
         self.mpiexec_executable = mpiexec_executable or "srun --mpi=pmi2"

--- a/adaptive_scheduler/_server_support/slurm_run.py
+++ b/adaptive_scheduler/_server_support/slurm_run.py
@@ -120,6 +120,7 @@ def slurm_run(
         cores_per_node=cores_per_node,
         partition=partition,
         log_folder=folder / "logs",
+        batch_folder=folder / "batch_scripts",
         executor_type=executor_type,
         num_threads=num_threads,
     )

--- a/adaptive_scheduler/_server_support/slurm_run.py
+++ b/adaptive_scheduler/_server_support/slurm_run.py
@@ -136,7 +136,7 @@ def slurm_run(
         save_interval=save_interval,
         log_interval=log_interval,
         move_old_logs_to=folder / "old_logs",
-        db_fname=f"{name}.db.json",
+        db_fname=folder / f"{name}.db.json",
         job_name=name,
         cleanup_first=cleanup_first,
         save_dataframe=save_dataframe,

--- a/tests/test_slurm_scheduler.py
+++ b/tests/test_slurm_scheduler.py
@@ -89,7 +89,7 @@ def test_start_job(tmp_path: Path) -> None:
         s.write_job_script("testjob", {})
         s.start_job("testjob")
         mock_submit.assert_called_once_with(
-            f"sbatch --job-name testjob --output {tmp_path}/testjob-%A.out testjob.sbatch",
+            f"sbatch --job-name testjob --output {tmp_path}/testjob-%A.out {tmp_path}/testjob.sbatch",
             "testjob",
         )
         sbatch_file = tmp_path / "testjob.sbatch"


### PR DESCRIPTION
This PR modifies the behavior of 'adaptive_scheduler.slurm_run' so that the database file and batch scripts are placed inside the directory specified by the 'folder' parameter.

Previously these files would be placed in the working directory of the Python process from which 'slurm_run' was invoked.
This change improves isolation between different adaptive-scheduler runs.