### PR TITLE
Fix LocalMockScheduler to properly kill its jobs

### DIFF
--- a/adaptive_scheduler/_scheduler/base_scheduler.py
+++ b/adaptive_scheduler/_scheduler/base_scheduler.py
@@ -344,7 +344,7 @@ class BaseScheduler(abc.ABC):
 
     def start_job(self, name: str) -> None:
         """Writes a job script and submits it to the scheduler."""
-        submit_cmd = f"{self.submit_cmd} {self.batch_fname(name)}"
+        submit_cmd = f"{self.submit_cmd} {name} {self.batch_fname(name)}"
         run_submit(submit_cmd)
 
     def __getstate__(self) -> dict[str, Any]:

--- a/adaptive_scheduler/_scheduler/local.py
+++ b/adaptive_scheduler/_scheduler/local.py
@@ -16,10 +16,7 @@ if TYPE_CHECKING:
 
 
 class LocalMockScheduler(BaseScheduler):
-    """A scheduler that can be used for testing and runs locally.
-
-    CANCELLING DOESN'T WORK ATM, ALSO LEAVES ZOMBIE PROCESSES!
-    """
+    """A scheduler that can be used for testing and runs locally."""
 
     # Attributes that all schedulers need to have
     _ext = ".batch"
@@ -118,7 +115,9 @@ class LocalMockScheduler(BaseScheduler):
 
     def start_job(self, name: str) -> None:
         """Start a job."""
-        submit_cmd = f"{self.submit_cmd} {name} {self.batch_fname(name)}"
+        print("name", name)
+        name_prefix = name.rsplit("-", 1)[0]
+        submit_cmd = f"{self.submit_cmd} {name} {self.batch_fname(name_prefix)}"
         run_submit(submit_cmd, name)
 
     @property

--- a/adaptive_scheduler/_scheduler/local.py
+++ b/adaptive_scheduler/_scheduler/local.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import textwrap
-import warnings
 from typing import TYPE_CHECKING
 
 from adaptive_scheduler._scheduler.base_scheduler import BaseScheduler
@@ -41,7 +40,6 @@ class LocalMockScheduler(BaseScheduler):
         """Initialize the LocalMockScheduler."""
         import adaptive_scheduler._mock_scheduler
 
-        warnings.warn("The LocalMockScheduler currently doesn't work!", stacklevel=2)
         super().__init__(
             cores,
             python_executable=python_executable,

--- a/adaptive_scheduler/_scheduler/local.py
+++ b/adaptive_scheduler/_scheduler/local.py
@@ -115,7 +115,6 @@ class LocalMockScheduler(BaseScheduler):
 
     def start_job(self, name: str) -> None:
         """Start a job."""
-        print("name", name)
         name_prefix = name.rsplit("-", 1)[0]
         submit_cmd = f"{self.submit_cmd} {name} {self.batch_fname(name_prefix)}"
         run_submit(submit_cmd, name)


### PR DESCRIPTION
Test with:
```python
from functools import partial

import adaptive
import adaptive_scheduler


def h(x, width=0.01, offset=0):
    a = width
    return x + a ** 2 / (a ** 2 + (x - offset) ** 2)


offsets = [i / 10 - 0.5 for i in range(5)]

combos = adaptive.utils.named_product(offset=offsets, width=[0.01, 0.05])

learners = []
fnames = []

for combo in combos:
    f = partial(h, **combo)
    learner = adaptive.Learner1D(f, bounds=(-1, 1))
    fname = adaptive_scheduler.utils.combo2fname(combo, folder="data")
    fnames.append(fname)
    learners.append(learner)

name = "local-example"
scheduler = adaptive_scheduler.scheduler.LocalMockScheduler(
    cores=1,
    executor_type="loky",
    log_folder="logs",
    extra_script='echo "NAME=${NAME},JOB_ID=${JOB_ID}" >> test.txt',
)
run_manager = adaptive_scheduler.RunManager(
    learners=learners,
    fnames=fnames,
    scheduler=scheduler,
    goal=0.01,
    job_name=f"{name}",
    max_fails_per_job=5,
    max_simultaneous_jobs=50,
    db_fname=f"{name}-database.json",
    log_interval=30,
    save_interval=30,
    save_dataframe=True,
    cleanup_first=False,
)
run_manager.start()
```