### PR TITLE
Remove defaults from doc-strings

### DIFF
--- a/adaptive_scheduler/_mock_scheduler.py
+++ b/adaptive_scheduler/_mock_scheduler.py
@@ -49,7 +49,7 @@ class MockScheduler:
         Maximum number of simultaneously running jobs.
     refresh_interval : int
         Refresh interval of checking whether proccesses are still running.
-    bash : str, default: "bash"
+    bash : str
         ``bash`` executable.
     url : str, optional
         The URL of the socket. Defaults to {DEFAULT_URL}.

--- a/adaptive_scheduler/_scheduler/base_scheduler.py
+++ b/adaptive_scheduler/_scheduler/base_scheduler.py
@@ -29,10 +29,10 @@ class BaseScheduler(abc.ABC):
     ----------
     cores : int
         Number of cores per job (so per learner.)
-    python_executable : str, default: `sys.executable`
+    python_executable : str
         The Python executable that should run adaptive-scheduler. By default
         it uses the same Python as where this function is called.
-    log_folder : str, default: ""
+    log_folder : str
         The folder in which to put the log-files.
     mpiexec_executable : str, optional
         ``mpiexec`` executable. By default `mpiexec` will be
@@ -41,7 +41,7 @@ class BaseScheduler(abc.ABC):
         The executor that is used, by default `mpi4py.futures.MPIPoolExecutor` is used.
         One can use ``"ipyparallel"``, ``"dask-mpi"``, ``"mpi4py"``,
         ``"loky"``, or ``"process-pool"``.
-    num_threads : int, default 1
+    num_threads : int
         ``MKL_NUM_THREADS``, ``OPENBLAS_NUM_THREADS``, ``OMP_NUM_THREADS``, and
         ``NUMEXPR_NUM_THREADS`` will be set to this number.
     extra_scheduler : list, optional
@@ -53,7 +53,7 @@ class BaseScheduler(abc.ABC):
     extra_script : str, optional
         Extra script that will be executed after any environment variables are set,
         but before the main scheduler is run.
-    batch_folder : str, default: ""
+    batch_folder : str
         The folder in which to put the batch files.
 
     Returns
@@ -99,7 +99,7 @@ class BaseScheduler(abc.ABC):
 
         Parameters
         ----------
-        me_only : bool, default: True
+        me_only : bool
             Only see your jobs.
 
         Returns
@@ -176,9 +176,9 @@ class BaseScheduler(abc.ABC):
         ----------
         job_names : list
             List of job names.
-        with_progress_bar : bool, default: True
+        with_progress_bar : bool
             Display a progress bar using `tqdm`.
-        max_tries : int, default: 5
+        max_tries : int
             Maximum number of attempts to cancel a job.
         """
 

--- a/adaptive_scheduler/_scheduler/slurm.py
+++ b/adaptive_scheduler/_scheduler/slurm.py
@@ -36,7 +36,7 @@ class SLURM(BaseScheduler):
         The SLURM partition to submit the job to.
     exclusive : bool
         Whether to use exclusive nodes (e.g., if SLURM it adds ``--exclusive`` as option).
-    log_folder : str, default: ""
+    log_folder : str
         The folder in which to put the log-files.
     mpiexec_executable : str, optional
         ``mpiexec`` executable. By default `mpiexec` will be
@@ -45,7 +45,7 @@ class SLURM(BaseScheduler):
         The executor that is used, by default `mpi4py.futures.MPIPoolExecutor` is used.
         One can use ``"ipyparallel"``, ``"dask-mpi"``, ``"mpi4py"``,
         ``"loky"``, or ``"process-pool"``.
-    num_threads : int, default 1
+    num_threads : int
         ``MKL_NUM_THREADS``, ``OPENBLAS_NUM_THREADS``, ``OMP_NUM_THREADS``, and
         ``NUMEXPR_NUM_THREADS`` will be set to this number.
     extra_scheduler : list, optional

--- a/adaptive_scheduler/_server_support/common.py
+++ b/adaptive_scheduler/_server_support/common.py
@@ -91,13 +91,11 @@ def cleanup_scheduler_files(
         List of job names.
     scheduler : `~adaptive_scheduler.scheduler.BaseScheduler`
         A scheduler instance from `adaptive_scheduler.scheduler`.
-    with_progress_bar : bool, default: True
+    with_progress_bar : bool
         Display a progress bar using `tqdm`.
-    move_to : str, default: None
+    move_to : str
         Move the file to a different directory.
         If None the file is removed.
-    log_file_folder : str, default: ''
-        The folder in which to delete the log-files.
     """
     to_rm = _get_all_files(job_names, scheduler)
 
@@ -156,7 +154,7 @@ def periodically_clean_ipython_profiles(
     ----------
     scheduler : `~adaptive_scheduler.scheduler.BaseScheduler`
         A scheduler instance from `adaptive_scheduler.scheduler`.
-    interval : int, default: 600
+    interval : int
         The interval at which to remove old profiles.
 
     Returns

--- a/adaptive_scheduler/_server_support/database_manager.py
+++ b/adaptive_scheduler/_server_support/database_manager.py
@@ -141,9 +141,9 @@ class DatabaseManager(BaseManager):
         List of `learners` corresponding to `fnames`.
     fnames : list
         List of `fnames` corresponding to `learners`.
-    overwrite_db : bool, default: True
+    overwrite_db : bool
         Overwrite the existing database upon starting.
-    initializers : list of callables, default: None
+    initializers : list of callables
         List of functions that are called before the job starts, can populate
         a cache.
 

--- a/adaptive_scheduler/_server_support/job_manager.py
+++ b/adaptive_scheduler/_server_support/job_manager.py
@@ -40,18 +40,18 @@ def command_line_options(
         A scheduler instance from `adaptive_scheduler.scheduler`.
     database_manager
         A database manager instance.
-    runner_kwargs : dict, default: None
+    runner_kwargs : dict
         Extra keyword argument to pass to the `adaptive.Runner`. Note that this dict
         will be serialized and pasted in the ``job_script``.
-    goal : callable, default: None
+    goal : callable
         The goal passed to the `adaptive.Runner`. Note that this function will
         be serialized and pasted in the ``job_script``. Can be a smart-goal
         that accepts
         ``Callable[[adaptive.BaseLearner], bool] | int | float | datetime | timedelta | None``.
         See `adaptive_scheduler.utils.smart_goal` for more information.
-    log_interval : int, default: 300
+    log_interval : int
         Time in seconds between log entries.
-    save_interval : int, default: 300
+    save_interval : int
         Time in seconds between saving of the learners.
     save_dataframe : bool
         Whether to periodically save the learner's data as a `pandas.DataFame`.
@@ -102,14 +102,14 @@ class JobManager(BaseManager):
         A `DatabaseManager` instance.
     scheduler : `~adaptive_scheduler.scheduler.BaseScheduler`
         A scheduler instance from `adaptive_scheduler.scheduler`.
-    interval : int, default: 30
+    interval : int
         Time in seconds between checking and starting jobs.
-    max_simultaneous_jobs : int, default: 500
+    max_simultaneous_jobs : int
         Maximum number of simultaneously running jobs. By default no more than 500
         jobs will be running. Keep in mind that if you do not specify a ``runner.goal``,
         jobs will run forever, resulting in the jobs that were not initially started
         (because of this `max_simultaneous_jobs` condition) to not ever start.
-    max_fails_per_job : int, default: 40
+    max_fails_per_job : int
         Maximum number of times that a job can fail. This is here as a fail switch
         because a job might fail instantly because of a bug inside your code.
         The job manager will stop when
@@ -120,14 +120,14 @@ class JobManager(BaseManager):
         The format in which to save the `pandas.DataFame`. See the type hint for the options.
     loky_start_method : str
         Loky start method, by default "loky".
-    log_interval : int, default: 300
+    log_interval : int
         Time in seconds between log entries.
-    save_interval : int, default: 300
+    save_interval : int
         Time in seconds between saving of the learners.
-    runner_kwargs : dict, default: None
+    runner_kwargs : dict
         Extra keyword argument to pass to the `adaptive.Runner`. Note that this dict
         will be serialized and pasted in the ``job_script``.
-    goal : callable, default: None
+    goal : callable
         The goal passed to the `adaptive.Runner`. Note that this function will
         be serialized and pasted in the ``job_script``. Can be a smart-goal
         that accepts

--- a/adaptive_scheduler/_server_support/kill_manager.py
+++ b/adaptive_scheduler/_server_support/kill_manager.py
@@ -77,15 +77,15 @@ class KillManager(BaseManager):
         A scheduler instance from `adaptive_scheduler.scheduler`.
     database_manager : `DatabaseManager`
         A `DatabaseManager` instance.
-    error : str or callable, default: "srun: error:"
+    error : str or callable
         If ``error`` is a string and is found in the log files, the job will
         be cancelled and restarted. If it is a callable, it is applied
         to the log text. Must take a single argument, a list of
         strings, and return True if the job has to be killed, or
         False if not.
-    interval : int, default: 600
+    interval : int
         Time in seconds between checking for the condition.
-    max_cancel_tries : int, default: 5
+    max_cancel_tries : int
         Try maximum `max_cancel_tries` times to cancel a job.
     move_to : str, optional
         If a job is cancelled the log is either removed (if ``move_to=None``)

--- a/adaptive_scheduler/_server_support/parse_logs.py
+++ b/adaptive_scheduler/_server_support/parse_logs.py
@@ -46,7 +46,7 @@ def parse_log_files(
         A `DatabaseManager` instance.
     scheduler : `~adaptive_scheduler.scheduler.BaseScheduler`
         A scheduler instance from `adaptive_scheduler.scheduler`.
-    only_last : bool, default: True
+    only_last : bool
         Only look use the last printed status message.
 
     Returns

--- a/adaptive_scheduler/_server_support/run_manager.py
+++ b/adaptive_scheduler/_server_support/run_manager.py
@@ -53,49 +53,49 @@ class RunManager(BaseManager):
         List of `learners` corresponding to `fnames`.
     fnames : list
         List of `fnames` corresponding to `learners`.
-    goal : callable, default: None
+    goal : callable
         The goal passed to the `adaptive.Runner`. Note that this function will
         be serialized and pasted in the ``job_script``. Can be a smart-goal
         that accepts
         ``Callable[[adaptive.BaseLearner], bool] | int | float | datetime | timedelta | None``.
         See `adaptive_scheduler.utils.smart_goal` for more information.
-    initializers : list of callables, default: None
+    initializers : list of callables
         List of functions that are called before the job starts, can populate
         a cache.
-    check_goal_on_start : bool, default: True
+    check_goal_on_start : bool
         Checks whether a learner is already done. Only works if the learner is loaded.
-    runner_kwargs : dict, default: None
+    runner_kwargs : dict
         Extra keyword argument to pass to the `adaptive.Runner`. Note that this dict
         will be serialized and pasted in the ``job_script``.
-    url : str, default: None
+    url : str
         The url of the database manager, with the format
         ``tcp://ip_of_this_machine:allowed_port.``. If None, a correct url will be chosen.
-    save_interval : int, default: 300
+    save_interval : int
         Time in seconds between saving of the learners.
-    log_interval : int, default: 300
+    log_interval : int
         Time in seconds between log entries.
-    job_name : str, default: "adaptive-scheduler"
+    job_name : str
         From this string the job names will be created, e.g.
         ``["adaptive-scheduler-1", "adaptive-scheduler-2", ...]``.
-    job_manager_interval : int, default: 60
+    job_manager_interval : int
         Time in seconds between checking and starting jobs.
-    kill_interval : int, default: 60
+    kill_interval : int
         Check for `kill_on_error` string inside the log-files every `kill_interval` seconds.
-    kill_on_error : str or callable, default: "srun: error:"
+    kill_on_error : str or callable
         If ``error`` is a string and is found in the log files, the job will
         be cancelled and restarted. If it is a callable, it is applied
         to the log text. Must take a single argument, a list of
         strings, and return True if the job has to be killed, or
         False if not. Set to None if no `KillManager` is needed.
-    move_old_logs_to : str, default: "old_logs"
+    move_old_logs_to : str
         Move logs of killed jobs to this directory. If None the logs will be deleted.
-    db_fname : str, default: "running.json"
+    db_fname : str
         Filename of the database, e.g. 'running.json'.
-    overwrite_db : bool, default: True
+    overwrite_db : bool
         Overwrite the existing database.
-    job_manager_kwargs : dict, default: None
+    job_manager_kwargs : dict
         Keyword arguments for the `JobManager` function that aren't set in ``__init__`` here.
-    kill_manager_kwargs : dict, default: None
+    kill_manager_kwargs : dict
         Keyword arguments for the `KillManager` function that aren't set in ``__init__`` here.
     loky_start_method : str
         Loky start method, by default "loky".
@@ -377,7 +377,7 @@ class RunManager(BaseManager):
 
         Parameters
         ----------
-        only_last : bool, default: True
+        only_last : bool
             Only look use the last printed status message.
 
         Returns
@@ -513,12 +513,12 @@ def start_one_by_one(
     ----------
     run_managers : list[RunManager]
         A list of RunManagers.
-    goal : callable, default: None
+    goal : callable
         A callable that takes a RunManager as argument and returns a boolean.
         If `goal` is not None, the RunManagers will be started after `goal`
         returns True for the previous RunManager. If `goal` is None, the
         RunManagers will be started after the previous RunManager has finished.
-    interval : int, default: 120
+    interval : int
         The interval at which to check if `goal` is True. Only used if `goal`
         is not None.
 

--- a/adaptive_scheduler/_server_support/slurm_run.py
+++ b/adaptive_scheduler/_server_support/slurm_run.py
@@ -52,45 +52,45 @@ def slurm_run(
         (The one marked with a * in `sinfo`). Use
         `adaptive_scheduler.scheduler.slurm_partitions` to see the
         available partitions.
-    nodes : int, default: 1
+    nodes : int
         The number of nodes to use.
-    cores_per_node : int, default: None
+    cores_per_node : int
         The number of cores per node to use. If None, then all cores on the partition
         will be used.
-    goal : callable, int, float, datetime.timedelta, datetime.datetime, default: None
+    goal : callable, int, float, datetime.timedelta, datetime.datetime
         The goal of the adaptive run. If None, then the run will continue
         indefinitely.
-    folder : str or pathlib.Path, default: ""
+    folder : str or pathlib.Path
         The folder to save the learners in.
-    name : str, default: "adaptive"
+    name : str
         The name of the job.
-    num_threads : int, default: 1
+    num_threads : int
         The number of threads to use.
-    save_interval : int, default: 300
+    save_interval : int
         The interval at which to save the learners.
-    log_interval : int, default: 300
+    log_interval : int
         The interval at which to log the status of the run.
-    cleanup_first : bool, default: True
+    cleanup_first : bool
         Whether to clean up the folder before starting the run.
-    save_dataframe : bool, default: True
+    save_dataframe : bool
         Whether to save the `pandas.DataFrame`s with the learners data.
-    dataframe_format : str, default: "pickle"
+    dataframe_format : str
         The format to save the `pandas.DataFrame`s in. See
         `adaptive_scheduler.utils.save_dataframes` for more information.
-    max_fails_per_job : int, default: 50
+    max_fails_per_job : int
         The maximum number of times a job can fail before it is cancelled.
-    max_simultaneous_jobs : int, default: 500
+    max_simultaneous_jobs : int
         The maximum number of simultaneous jobs.
     executor_type : str
         The type of executor to use. One of "ipyparallel", "dask-mpi", "mpi4py",
         "loky", or "process-pool".
-    exclusive : bool, default: True
+    exclusive : bool
         Whether to use exclusive nodes, adds ``"--exclusive"`` if True.
-    extra_run_manager_kwargs : dict, default: None
+    extra_run_manager_kwargs : dict
         Extra keyword arguments to pass to the `RunManager`.
-    extra_scheduler_kwargs : dict, default: None
+    extra_scheduler_kwargs : dict
         Extra keyword arguments to pass to the `SLURMScheduler`.
-    initializers : list of callables, default: None
+    initializers : list of callables
         List of functions that are called before the job starts, can populate
         a cache.
 

--- a/adaptive_scheduler/client_support.py
+++ b/adaptive_scheduler/client_support.py
@@ -171,7 +171,7 @@ def log_info(runner: AsyncRunner, interval: int | float = 300) -> asyncio.Task:
     ----------
     runner : `adaptive.Runner` instance
         Adaptive Runner instance.
-    interval : int | float, default: 300
+    interval : int | float
         Time in seconds between log entries.
 
     Returns

--- a/adaptive_scheduler/utils.py
+++ b/adaptive_scheduler/utils.py
@@ -399,12 +399,12 @@ def _remove_or_move_files(
     ----------
     fnames : list
         List of filenames.
-    with_progress_bar : bool, default: True
+    with_progress_bar : bool
         Display a progress bar using `tqdm`.
-    move_to : str | Path, default None
+    move_to : str | Path
         Move the file to a different directory.
         If None the file is removed.
-    desc : str, default: None
+    desc : str
         Description of the progressbar.
     """
     n_failed = 0
@@ -444,7 +444,7 @@ def load_parallel(
         The learners to be loaded.
     fnames : sequence of str
         A list of filenames corresponding to `learners`.
-    with_progress_bar : bool, default True
+    with_progress_bar : bool
         Display a progress bar using `tqdm`.
     max_workers : int, optional
         The maximum number of parallel threads when loading the data.
@@ -476,7 +476,7 @@ def save_parallel(
         The learners to be saved.
     fnames : sequence of str
         A list of filenames corresponding to `learners`.
-    with_progress_bar : bool, default True
+    with_progress_bar : bool
         Display a progress bar using `tqdm`.
     """
 


### PR DESCRIPTION
Some seemed to have gotten out of sync, and since they're available in the function signature, they do not serve any purpose.