### PR TITLE
Fix job failure detection when jobs fail before issuing a start request

### DIFF
--- a/adaptive_scheduler/_server_support/database_manager.py
+++ b/adaptive_scheduler/_server_support/database_manager.py
@@ -252,7 +252,7 @@ class DatabaseManager(BaseManager):
             for f in output_fnames
         ]
 
-    def _choose_fname(self, job_name: str) -> tuple[int, str | list[str] | None]:
+    def _choose_fname(self) -> tuple[int, str | list[str] | None]:
         assert self._db is not None
         entry = self._db.get(
             lambda e: e.job_id is None and not e.is_done and not e.is_pending,
@@ -262,6 +262,10 @@ class DatabaseManager(BaseManager):
             raise RuntimeError(msg)
         log.debug("choose fname", entry=entry)
         index = self._db.all().index(entry)
+        return index, _ensure_str(entry.fname)  # type: ignore[return-value]
+
+    def _confirm_submitted(self, index: int, job_name: str) -> None:
+        assert self._db is not None
         self._db.update(
             {
                 "job_name": job_name,
@@ -269,7 +273,6 @@ class DatabaseManager(BaseManager):
             },
             indices=[index],
         )
-        return index, _ensure_str(entry.fname)  # type: ignore[return-value]
 
     def _start_request(
         self,

--- a/adaptive_scheduler/_server_support/database_manager.py
+++ b/adaptive_scheduler/_server_support/database_manager.py
@@ -200,8 +200,9 @@ class DatabaseManager(BaseManager):
             return
         if queue is None:
             queue = self.scheduler.queue(me_only=True)
+        job_names_in_queue = [x["job_name"] for x in queue.values()]
         failed = self._db.get_all(
-            lambda e: (e.job_id is not None) and (e.job_id not in queue),  # type: ignore[operator]
+            lambda e: e.job_name is not None and e.job_name not in job_names_in_queue,  # type: ignore[operator]
         )
         self.failed.extend([asdict(entry) for _, entry in failed])
         indices = [index for index, _ in failed]

--- a/adaptive_scheduler/_server_support/job_manager.py
+++ b/adaptive_scheduler/_server_support/job_manager.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-from concurrent.futures import ThreadPoolExecutor
-from functools import partial
 from typing import TYPE_CHECKING, Any
 
 from adaptive_scheduler.utils import _now, _serialize_to_b64, sleep_unless_task_is_done
@@ -233,8 +231,6 @@ class JobManager(BaseManager):
         self,
         not_queued: set[str],
         queued: set[str],
-        ex: ThreadPoolExecutor,
-        loop: asyncio.AbstractEventLoop,
     ) -> None:
         num_jobs_to_start = min(
             len(not_queued),
@@ -247,49 +243,50 @@ class JobManager(BaseManager):
             log.debug(
                 f"Starting `job_name={job_name}` with `index={index}` and `fname={fname}`",
             )
-            await loop.run_in_executor(
-                ex,
-                partial(self.scheduler.start_job, name=job_name, index=index),
-            )
+            # Synchronously start the job and ensure the database is updated.
+            # Making this asynchronous can lead to race conditions.
+            # TODO: remove this by changing how '_choose_fname' works.
+            self.scheduler.start_job(name=job_name, index=index)
+            self.database_manager.update()
+
             self.n_started += 1
             self._request_times[job_name] = _now()
+            # 'start_job' might take a while, so ensure we give other tasks
+            # the opportunity to run.
+            await asyncio.sleep(0)
 
     async def _manage(self) -> None:
-        loop = asyncio.get_event_loop()
-        with ThreadPoolExecutor() as ex:  # TODO: use asyncio.to_thread when Python≥3.9
-            while True:
-                try:
-                    update = await self._update_database_and_get_not_queued()
-                    if update is None:  # we are finished!
-                        return
-                    queued, not_queued = update
-                    await self._start_new_jobs(not_queued, queued, ex, loop)
-                    if self.n_started > self.max_job_starts:
-                        msg = (
-                            "Too many jobs failed, your Python code probably has a bug."
-                        )
-                        raise MaxRestartsReachedError(msg)  # noqa: TRY301
-                    if await sleep_unless_task_is_done(
-                        self.database_manager.task,  # type: ignore[arg-type]
-                        self.interval,
-                    ):  # if true, we are done
-                        return
-                except asyncio.CancelledError:  # noqa: PERF203
-                    log.info("task was cancelled because of a CancelledError")
-                    raise
-                except MaxRestartsReachedError as e:
-                    log.exception(
-                        "too many jobs have failed, cancelling the job manager",
-                        n_started=self.n_started,
-                        max_fails_per_job=self.max_fails_per_job,
-                        max_job_starts=self.max_job_starts,
-                        exception=str(e),
-                    )
-                    raise
-                except Exception as e:  # noqa: BLE001
-                    log.exception("got exception when starting a job", exception=str(e))
-                    if await sleep_unless_task_is_done(
-                        self.database_manager.task,  # type: ignore[arg-type]
-                        5,
-                    ):  # if true, we are done
-                        return
+        while True:
+            try:
+                update = await self._update_database_and_get_not_queued()
+                if update is None:  # we are finished!
+                    return
+                queued, not_queued = update
+                await self._start_new_jobs(not_queued, queued)
+                if self.n_started > self.max_job_starts:
+                    msg = "Too many jobs failed, your Python code probably has a bug."
+                    raise MaxRestartsReachedError(msg)  # noqa: TRY301
+                if await sleep_unless_task_is_done(
+                    self.database_manager.task,  # type: ignore[arg-type]
+                    self.interval,
+                ):  # if true, we are done
+                    return
+            except asyncio.CancelledError:  # noqa: PERF203
+                log.info("task was cancelled because of a CancelledError")
+                raise
+            except MaxRestartsReachedError as e:
+                log.exception(
+                    "too many jobs have failed, cancelling the job manager",
+                    n_started=self.n_started,
+                    max_fails_per_job=self.max_fails_per_job,
+                    max_job_starts=self.max_job_starts,
+                    exception=str(e),
+                )
+                raise
+            except Exception as e:  # noqa: BLE001
+                log.exception("got exception when starting a job", exception=str(e))
+                if await sleep_unless_task_is_done(
+                    self.database_manager.task,  # type: ignore[arg-type]
+                    5,
+                ):  # if true, we are done
+                    return

--- a/adaptive_scheduler/_server_support/job_manager.py
+++ b/adaptive_scheduler/_server_support/job_manager.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import asyncio
+from concurrent.futures import ThreadPoolExecutor
+from functools import partial
 from typing import TYPE_CHECKING, Any
 
 from adaptive_scheduler.utils import _now, _serialize_to_b64, sleep_unless_task_is_done
@@ -231,6 +233,8 @@ class JobManager(BaseManager):
         self,
         not_queued: set[str],
         queued: set[str],
+        ex: ThreadPoolExecutor,
+        loop: asyncio.AbstractEventLoop,
     ) -> None:
         num_jobs_to_start = min(
             len(not_queued),
@@ -239,54 +243,56 @@ class JobManager(BaseManager):
         for _ in range(num_jobs_to_start):
             job_name = not_queued.pop()
             queued.add(job_name)
-            index, fname = self.database_manager._choose_fname(job_name)
+
+            index, fname = self.database_manager._choose_fname()
             log.debug(
                 f"Starting `job_name={job_name}` with `index={index}` and `fname={fname}`",
             )
-            # Synchronously start the job and ensure the database is updated.
-            # Making this asynchronous can lead to race conditions.
-            # TODO: remove this by changing how '_choose_fname' works.
-            self.scheduler.start_job(name=job_name, index=index)
-            self.database_manager.update()
+            await loop.run_in_executor(
+                ex,
+                partial(self.scheduler.start_job, name=job_name, index=index),
+            )
+            self.database_manager._confirm_submitted(index, job_name)
 
             self.n_started += 1
             self._request_times[job_name] = _now()
-            # 'start_job' might take a while, so ensure we give other tasks
-            # the opportunity to run.
-            await asyncio.sleep(0)
 
     async def _manage(self) -> None:
-        while True:
-            try:
-                update = await self._update_database_and_get_not_queued()
-                if update is None:  # we are finished!
-                    return
-                queued, not_queued = update
-                await self._start_new_jobs(not_queued, queued)
-                if self.n_started > self.max_job_starts:
-                    msg = "Too many jobs failed, your Python code probably has a bug."
-                    raise MaxRestartsReachedError(msg)  # noqa: TRY301
-                if await sleep_unless_task_is_done(
-                    self.database_manager.task,  # type: ignore[arg-type]
-                    self.interval,
-                ):  # if true, we are done
-                    return
-            except asyncio.CancelledError:  # noqa: PERF203
-                log.info("task was cancelled because of a CancelledError")
-                raise
-            except MaxRestartsReachedError as e:
-                log.exception(
-                    "too many jobs have failed, cancelling the job manager",
-                    n_started=self.n_started,
-                    max_fails_per_job=self.max_fails_per_job,
-                    max_job_starts=self.max_job_starts,
-                    exception=str(e),
-                )
-                raise
-            except Exception as e:  # noqa: BLE001
-                log.exception("got exception when starting a job", exception=str(e))
-                if await sleep_unless_task_is_done(
-                    self.database_manager.task,  # type: ignore[arg-type]
-                    5,
-                ):  # if true, we are done
-                    return
+        loop = asyncio.get_event_loop()
+        with ThreadPoolExecutor() as ex:  # TODO: use asyncio.to_thread when Python≥3.9
+            while True:
+                try:
+                    update = await self._update_database_and_get_not_queued()
+                    if update is None:  # we are finished!
+                        return
+                    queued, not_queued = update
+                    await self._start_new_jobs(not_queued, queued, ex, loop)
+                    if self.n_started > self.max_job_starts:
+                        msg = (
+                            "Too many jobs failed, your Python code probably has a bug."
+                        )
+                        raise MaxRestartsReachedError(msg)  # noqa: TRY301
+                    if await sleep_unless_task_is_done(
+                        self.database_manager.task,  # type: ignore[arg-type]
+                        self.interval,
+                    ):  # if true, we are done
+                        return
+                except asyncio.CancelledError:  # noqa: PERF203
+                    log.info("task was cancelled because of a CancelledError")
+                    raise
+                except MaxRestartsReachedError as e:
+                    log.exception(
+                        "too many jobs have failed, cancelling the job manager",
+                        n_started=self.n_started,
+                        max_fails_per_job=self.max_fails_per_job,
+                        max_job_starts=self.max_job_starts,
+                        exception=str(e),
+                    )
+                    raise
+                except Exception as e:  # noqa: BLE001
+                    log.exception("got exception when starting a job", exception=str(e))
+                    if await sleep_unless_task_is_done(
+                        self.database_manager.task,  # type: ignore[arg-type]
+                        5,
+                    ):  # if true, we are done
+                        return

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,7 +135,7 @@ ignore = [
 ]
 
 [tool.ruff.lint.per-file-ignores]
-"tests/*" = ["SLF001", "PLR2004"]
+"tests/*" = ["SLF001", "PLR2004", "PLR0915"]
 "tests/test_examples.py" = ["E501"]
 ".github/*" = ["INP001"]
 

--- a/tests/test_kill_manager.py
+++ b/tests/test_kill_manager.py
@@ -152,7 +152,8 @@ async def test_kill_manager_manage(kill_manager: KillManager) -> None:
     kill_manager.start()
     assert kill_manager.task is not None
     # Marks the job as running, and sets the job_id, job_name, and log_fname
-    kill_manager.database_manager._choose_fname("test_job")
+    index, _ = kill_manager.database_manager._choose_fname()
+    kill_manager.database_manager._confirm_submitted(index, "test_job")
     kill_manager.database_manager._start_request("0", "log_fname.log", "test_job")
     kill_manager.scheduler.start_job("test_job")
     await asyncio.sleep(0.1)  # Give it some time to start and cancel the job

--- a/tests/test_log_parsing.py
+++ b/tests/test_log_parsing.py
@@ -71,7 +71,8 @@ def test_parse_log_files(db_manager: DatabaseManager) -> None:
         job_name = "test_job"
         db_manager.start()
         # Add an entry in the database manager
-        db_manager._choose_fname(job_name)
+        index, _ = db_manager._choose_fname()
+        db_manager._confirm_submitted(index, job_name)
         db_manager._start_request("0", f.name, job_name)
         db_manager.scheduler.start_job(job_name)
 

--- a/tests/test_slurm_scheduler.py
+++ b/tests/test_slurm_scheduler.py
@@ -274,7 +274,7 @@ def test_slurm_scheduler_ipyparallel() -> None:
     )
 
 
-def test_multiple_jobs() -> None:  # noqa: PLR0915
+def test_multiple_jobs() -> None:
     """Test that multiple jobs can be started."""
     cores = (3, 4, 5)
     s = SLURM(cores=cores)

--- a/tests/test_utils_file_creation_progress.py
+++ b/tests/test_utils_file_creation_progress.py
@@ -86,7 +86,7 @@ async def test_track_file_creation_progress(tmp_path: Path) -> None:
     )
 
     # Allow some time for the task to process
-    await asyncio.sleep(0.05)
+    await asyncio.sleep(0.1)
 
     progress.stop()
     assert "Total" in progress._tasks[0].description
@@ -103,7 +103,7 @@ async def test_track_file_creation_progress(tmp_path: Path) -> None:
 
     # Create one of the files of category2, should still not be completed
     create_test_files(tmp_path, ["file3"])
-    await asyncio.sleep(0.05)
+    await asyncio.sleep(0.1)
 
     assert "category2" in progress._tasks[2].description
     assert progress._tasks[2].total == 1


### PR DESCRIPTION
Previously, adaptive-sheduler would not detect failures for jobs that failed before the start request had been received. This can happen when nodes are pre-empted while they are configuring.

This PR makes it so that jobs that fail in this early stage are detected, and the failure recorded in the database. 

Fixes #216. 