### PR TITLE
Set `exclusive=False` by default

### DIFF
--- a/adaptive_scheduler/_scheduler/slurm.py
+++ b/adaptive_scheduler/_scheduler/slurm.py
@@ -124,7 +124,7 @@ class SLURM(BaseScheduler):
         nodes: int | tuple[int | None | Callable[[], int | None], ...] | None = None,
         cores_per_node: int | tuple[int | None | Callable[[], int | None], ...] | None = None,
         partition: str | tuple[str | None | Callable[[], str | None], ...] | None = None,
-        exclusive: bool | tuple[bool | Callable[[], bool], ...] = True,
+        exclusive: bool | tuple[bool | Callable[[], bool], ...] = False,
         python_executable: str | None = None,
         log_folder: str | Path = "",
         mpiexec_executable: str | None = None,

--- a/adaptive_scheduler/_server_support/slurm_run.py
+++ b/adaptive_scheduler/_server_support/slurm_run.py
@@ -31,12 +31,13 @@ def slurm_run(
     num_threads: int | tuple[int | Callable[[], int], ...] = 1,
     save_interval: float = 300,
     log_interval: float = 300,
+    job_manager_interval: float = 60,
     cleanup_first: bool = True,
     save_dataframe: bool = True,
     dataframe_format: _DATAFRAME_FORMATS = "pickle",
     max_fails_per_job: int = 50,
     max_simultaneous_jobs: int = 100,
-    exclusive: bool | tuple[bool | Callable[[], bool], ...] = True,
+    exclusive: bool | tuple[bool | Callable[[], bool], ...] = False,
     executor_type: EXECUTOR_TYPES
     | tuple[EXECUTOR_TYPES | Callable[[], EXECUTOR_TYPES], ...] = "process-pool",
     extra_scheduler: list[str] | tuple[list[str] | Callable[[], list[str]], ...] | None = None,
@@ -90,6 +91,9 @@ def slurm_run(
         The interval at which to save the learners.
     log_interval
         The interval at which to log the status of the run.
+    job_manager_interval
+        The interval at which the job manager checks the status of the jobs and
+        submits new jobs.
     cleanup_first
         Whether to clean up the folder before starting the run.
     save_dataframe
@@ -197,6 +201,7 @@ def slurm_run(
         max_fails_per_job=max_fails_per_job,
         max_simultaneous_jobs=max_simultaneous_jobs,
         initializers=initializers,
+        job_manager_interval=job_manager_interval,
     )
     if extra_run_manager_kwargs is None:
         extra_run_manager_kwargs = {}

--- a/tests/test_slurm_run.py
+++ b/tests/test_slurm_run.py
@@ -46,7 +46,7 @@ def test_slurm_run_with_default_arguments(
     assert rm.log_interval == 300
     assert rm.learners == learners
     assert rm.fnames == fnames
-    assert rm.scheduler.exclusive is True
+    assert rm.scheduler.exclusive is False
 
 
 def goal_example(learner: adaptive.Learner1D) -> bool:

--- a/tests/test_slurm_scheduler.py
+++ b/tests/test_slurm_scheduler.py
@@ -72,7 +72,6 @@ def test_job_script() -> None:
     s = SLURM(cores=4)
     job_script = s.job_script(options={})
     assert "#SBATCH --ntasks 4" in job_script
-    assert "#SBATCH --exclusive" in job_script
     assert "#SBATCH --no-requeue" in job_script
     assert "MKL_NUM_THREADS=1" in job_script
     assert "OPENBLAS_NUM_THREADS=1" in job_script
@@ -112,7 +111,6 @@ def test_slurm_job_script_default() -> None:
 
     assert "#SBATCH --ntasks 4" in job_script
     assert "#SBATCH --no-requeue" in job_script
-    assert "#SBATCH --exclusive" in job_script
     assert "export MKL_NUM_THREADS=1" in job_script
     assert "export OPENBLAS_NUM_THREADS=1" in job_script
     assert "export OMP_NUM_THREADS=1" in job_script
@@ -188,7 +186,6 @@ def test_slurm_scheduler_job_script_ipyparallel() -> None:
         #!/bin/bash
         #SBATCH --ntasks 4
         #SBATCH --no-requeue
-        #SBATCH --exclusive
         #SBATCH --exclusive=user
         #SBATCH --time=1
 


### PR DESCRIPTION
Having it `True` is not a good default on small clusters. Since SLURM also doesn't set `--exclusive` by default, we'll change it.

cc @jbweston @aeantipov @jgukelberger for awareness 