### PR TITLE
Remove pyarrow dependency (introduced in #67)

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -18,7 +18,6 @@ dependencies:
   - numpy
   - pandas
   - psutil
-  - pyarrow
   - pyzmq
   - rich
   - structlog

--- a/environment.yml
+++ b/environment.yml
@@ -18,7 +18,6 @@ dependencies:
   - numpy
   - pandas
   - psutil
-  - pyarrow
   - pyzmq
   - rich
   - structlog

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,6 @@ dependencies = [
     "numpy",
     "pandas",
     "psutil",
-    "pyarrow",
     "pyzmq",
     "rich",
     "structlog",


### PR DESCRIPTION
Is no longer needed.

Was added in https://github.com/basnijholt/adaptive-scheduler/pull/67.