### PR TITLE
POC: CrossClusterSlurmExecutor with multi-cluster execution and retry logic

### DIFF
--- a/adaptive_scheduler/__init__.py
+++ b/adaptive_scheduler/__init__.py
@@ -1,6 +1,11 @@
 """Adaptive Scheduler."""
 
 from adaptive_scheduler import client_support, scheduler, server_support, utils
+from adaptive_scheduler._cross_cluster_executor import (
+    CrossClusterFuture,
+    CrossClusterSlurmExecutor,
+    RemoteJobError,
+)
 from adaptive_scheduler._executor import SlurmExecutor, SlurmTask
 from adaptive_scheduler._version import __version__
 from adaptive_scheduler.scheduler import PBS, SLURM
@@ -14,7 +19,10 @@ from adaptive_scheduler.server_support import (
 __all__ = [
     "PBS",
     "SLURM",
+    "CrossClusterFuture",
+    "CrossClusterSlurmExecutor",
     "MultiRunManager",
+    "RemoteJobError",
     "RunManager",
     "SlurmExecutor",
     "SlurmTask",

--- a/adaptive_scheduler/_cross_cluster_executor.py
+++ b/adaptive_scheduler/_cross_cluster_executor.py
@@ -440,7 +440,7 @@ class CrossClusterSlurmExecutor(concurrent.futures.Executor):
         future: CrossClusterFuture,
         task_dir: Path,
         state: str,
-        exit_code: str,
+        _exit_code: str,
     ) -> str:
         """Re-submit a failed job for retry.
 

--- a/adaptive_scheduler/_cross_cluster_executor.py
+++ b/adaptive_scheduler/_cross_cluster_executor.py
@@ -22,6 +22,7 @@ from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+
     from typing_extensions import Self
 
 import cloudpickle

--- a/adaptive_scheduler/_cross_cluster_executor.py
+++ b/adaptive_scheduler/_cross_cluster_executor.py
@@ -1,0 +1,463 @@
+"""Cross-cluster SLURM executor for SLURM multi-cluster.
+
+A ``concurrent.futures.Executor`` that runs each submitted callable as an
+independent SLURM job on a (possibly remote) cluster via ``sbatch -M`` and
+``sacct -M``.  File transfer between clusters is handled by SLURM's built-in
+CWD sync — ``sbatch`` is run from the task directory so SLURM syncs it to
+the remote cluster before the job starts and back after it completes.
+"""
+
+from __future__ import annotations
+
+import concurrent.futures
+import logging
+import pickle
+import subprocess
+import textwrap
+import threading
+import time
+import uuid
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from typing_extensions import Self
+
+import cloudpickle
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class RemoteJobError(RuntimeError):
+    """Raised when a SLURM job fails on the remote cluster."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        job_id: str | None = None,
+        exit_code: str | None = None,
+        state: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.job_id = job_id
+        self.exit_code = exit_code
+        self.state = state
+
+
+# ---------------------------------------------------------------------------
+# CrossClusterFuture
+# ---------------------------------------------------------------------------
+
+
+class CrossClusterFuture(concurrent.futures.Future):
+    """A Future whose result is produced by a SLURM job.
+
+    Adds ``job_id`` and ``cluster`` attributes, and overrides ``cancel()``
+    to issue ``scancel [-M cluster]``.
+    """
+
+    def __init__(self, *, job_id: str, cluster: str | None) -> None:
+        super().__init__()
+        self.job_id: str = job_id
+        self.cluster: str | None = cluster
+
+    def cancel(self) -> bool:
+        """Attempt to cancel the SLURM job via ``scancel``."""
+        if self.done():
+            return False
+        try:
+            cmd: list[str] = ["scancel"]
+            if self.cluster is not None:
+                cmd.append(f"-M{self.cluster}")
+            cmd.append(self.job_id)
+            subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+        except subprocess.CalledProcessError:
+            logger.warning("scancel failed for job %s", self.job_id)
+            return False
+        return super().cancel()
+
+
+# ---------------------------------------------------------------------------
+# CrossClusterSlurmExecutor
+# ---------------------------------------------------------------------------
+
+
+class CrossClusterSlurmExecutor(concurrent.futures.Executor):
+    """Execute callables as SLURM jobs on a (possibly remote) cluster.
+
+    Parameters
+    ----------
+    cluster
+        SLURM cluster name passed to ``sbatch -M`` / ``sacct -M``.
+        ``None`` means the local cluster (no ``-M`` flag).
+    partition
+        SLURM partition for job submission.
+    python_cmd
+        Python interpreter on the compute nodes.
+    base_dir
+        Base directory for job files (local to the submitting host).
+        ``~`` is expanded via ``Path.expanduser()``.  SLURM's CWD sync
+        transfers each task directory to/from the remote cluster.
+    extra_script
+        Shell snippet injected into every wrapper script (e.g. env activation).
+    extra_sbatch
+        Extra ``#SBATCH`` flags (e.g. ``["--comment=gcp-consent", "--time=10:00"]``).
+    poll_interval
+        Seconds between ``sacct`` polls.
+
+    """
+
+    def __init__(
+        self,
+        cluster: str | None = None,
+        partition: str = "short",
+        python_cmd: str = "python",
+        base_dir: str | Path = "~/cc-jobs",
+        extra_script: str = "",
+        extra_sbatch: list[str] | None = None,
+        poll_interval: float = 5.0,
+    ) -> None:
+        self.cluster = cluster
+        self.partition = partition
+        self.python_cmd = python_cmd
+        self.base_dir = Path(base_dir).expanduser()
+        self.extra_script = extra_script
+        self.extra_sbatch: list[str] = extra_sbatch or []
+        self.poll_interval = poll_interval
+
+        self._run_id = uuid.uuid4().hex[:12]
+        self._lock = threading.Lock()
+        self._pending: dict[
+            str,
+            tuple[CrossClusterFuture, Path],
+        ] = {}  # job_id -> (future, task_dir)
+        self._shutdown = False
+
+        # Start the monitor thread lazily on first submit
+        self._monitor_thread: threading.Thread | None = None
+
+    # -- public API --------------------------------------------------------
+
+    def submit(  # type: ignore[override]
+        self,
+        fn: Callable[..., Any],
+        /,
+        *args: Any,
+        **kwargs: Any,
+    ) -> CrossClusterFuture:
+        """Pickle *fn(args, kwargs)*, write to task dir, and ``sbatch``."""
+        with self._lock:
+            if self._shutdown:
+                msg = "Cannot submit to a shut-down executor"
+                raise RuntimeError(msg)
+
+        task_id = uuid.uuid4().hex[:12]
+        task_dir = self.base_dir / self._run_id / task_id
+
+        # 1. Create task directory on shared filesystem
+        task_dir.mkdir(parents=True, exist_ok=True)
+
+        # 2. Write pickled callable + arguments
+        payload = cloudpickle.dumps((fn, args, kwargs))
+        (task_dir / "input.pkl").write_bytes(payload)
+
+        # 3. Generate and write wrapper script
+        wrapper = self._make_wrapper(task_id)
+        (task_dir / "wrapper.sh").write_text(wrapper)
+
+        # 4. Submit via sbatch (from the task dir so SLURM syncs it)
+        job_id = self._sbatch(task_dir)
+
+        # 5. Create future and register with monitor
+        future = CrossClusterFuture(job_id=job_id, cluster=self.cluster)
+        with self._lock:
+            self._pending[job_id] = (future, task_dir)
+
+        cluster_name = self.cluster or "local"
+        logger.info("Submitted job %s (task %s) on %s", job_id, task_id, cluster_name)
+
+        # Start monitor thread if not running
+        self._ensure_monitor()
+
+        return future
+
+    def shutdown(self, wait: bool = True, *, cancel_futures: bool = False) -> None:  # noqa: FBT001, FBT002
+        """Shut down the executor.
+
+        Parameters
+        ----------
+        wait
+            Block until all futures are resolved.
+        cancel_futures
+            If True, cancel all pending jobs via ``scancel``.
+
+        """
+        with self._lock:
+            self._shutdown = True
+
+        if cancel_futures:
+            with self._lock:
+                pending_items = list(self._pending.items())
+            for _job_id, (future, _task_dir) in pending_items:
+                if not future.done():
+                    future.cancel()
+
+        if wait and self._monitor_thread is not None:
+            self._monitor_thread.join()
+
+    # -- context manager ---------------------------------------------------
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.shutdown(wait=True)
+
+    # -- internal ----------------------------------------------------------
+
+    def _make_wrapper(self, task_id: str) -> str:
+        """Generate the SBATCH wrapper script for a single task.
+
+        All paths are relative — sbatch is run from the task directory, and
+        SLURM's CWD sync ensures the files are available on the remote cluster.
+        """
+        lines = [
+            "#!/bin/bash",
+            f"#SBATCH --partition={self.partition}",
+            f"#SBATCH --job-name=cc-{task_id[:8]}",
+            "#SBATCH --output=stdout.log",
+            "#SBATCH --error=stderr.log",
+        ]
+        lines.extend(f"#SBATCH {flag}" for flag in self.extra_sbatch)
+        lines.append("")
+        if self.extra_script:
+            lines.append(self.extra_script)
+            lines.append("")
+        lines.append(f"{self.python_cmd} << 'PYTHON_EOF'")
+        lines.append(
+            textwrap.dedent("""\
+            import cloudpickle, pickle, sys, traceback
+            with open('input.pkl', 'rb') as f:
+                fn, args, kwargs = cloudpickle.load(f)
+            try:
+                result = fn(*args, **kwargs)
+                payload = {'status': 'ok', 'result': result}
+            except Exception as e:
+                payload = {'status': 'error', 'error': str(e), 'tb': traceback.format_exc()}
+            with open('output.pkl', 'wb') as f:
+                pickle.dump(payload, f)
+        """).rstrip(),
+        )
+        lines.append("PYTHON_EOF")
+        lines.append("")
+        return "\n".join(lines) + "\n"
+
+    def _sbatch(self, task_dir: Path) -> str:
+        """Submit ``wrapper.sh`` via ``sbatch`` from *task_dir*.
+
+        Running sbatch from the task directory ensures SLURM's CWD sync
+        transfers the directory contents to the remote cluster.
+        """
+        cmd: list[str] = ["sbatch"]
+        if self.cluster is not None:
+            cmd.append(f"-M{self.cluster}")
+        cmd.append("wrapper.sh")
+
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            check=True,
+            cwd=task_dir,
+        )
+        # Parse job ID from "Submitted batch job 12345 [on cluster ...]"
+        stdout = result.stdout.strip()
+        parts = stdout.split()
+        for i, part in enumerate(parts):
+            if part == "job" and i + 1 < len(parts):
+                return parts[i + 1]
+        msg = f"Could not parse job ID from sbatch output: {stdout}"
+        raise RuntimeError(msg)
+
+    def _ensure_monitor(self) -> None:
+        """Start the monitor thread if it isn't running yet."""
+        if self._monitor_thread is None or not self._monitor_thread.is_alive():
+            self._monitor_thread = threading.Thread(
+                target=self._monitor,
+                daemon=True,
+                name="cc-monitor",
+            )
+            self._monitor_thread.start()
+
+    def _monitor(self) -> None:
+        """Background thread: poll sacct and resolve futures."""
+        while True:
+            with self._lock:
+                if not self._pending:
+                    if self._shutdown:
+                        return
+                    pending_snapshot = {}
+                else:
+                    pending_snapshot = dict(self._pending)
+
+            if not pending_snapshot:
+                time.sleep(self.poll_interval)
+                continue
+
+            # Query sacct for all tracked jobs in one call
+            job_ids = list(pending_snapshot.keys())
+            states = self._query_sacct_batch(job_ids)
+
+            resolved: list[str] = []
+            for job_id, (future, task_dir) in pending_snapshot.items():
+                if future.done() or self._resolve_job(
+                    job_id,
+                    future,
+                    task_dir,
+                    states,
+                ):
+                    resolved.append(job_id)
+
+            # Remove resolved jobs from pending
+            if resolved:
+                with self._lock:
+                    for jid in resolved:
+                        self._pending.pop(jid, None)
+
+            # Check if we're done
+            with self._lock:
+                if not self._pending and self._shutdown:
+                    return
+
+            time.sleep(self.poll_interval)
+
+    def _resolve_job(
+        self,
+        job_id: str,
+        future: CrossClusterFuture,
+        task_dir: Path,
+        states: dict[str, tuple[str, str]],
+    ) -> bool:
+        """Try to resolve a single job. Return True if the job is resolved."""
+        state, exit_code = states.get(job_id, ("UNKNOWN", "?"))
+
+        if state in ("RUNNING", "PENDING", "UNKNOWN"):
+            return False
+
+        if state == "COMPLETED" and exit_code == "0:0":
+            self._resolve_completed_job(job_id, future, task_dir, exit_code, state)
+        else:
+            future.set_exception(
+                RemoteJobError(
+                    f"Job {job_id} failed with state={state}, exit_code={exit_code}. "
+                    f"Check logs at {task_dir}/stderr.log.",
+                    job_id=job_id,
+                    exit_code=exit_code,
+                    state=state,
+                ),
+            )
+        return True
+
+    def _resolve_completed_job(
+        self,
+        job_id: str,
+        future: CrossClusterFuture,
+        task_dir: Path,
+        exit_code: str,
+        state: str,
+    ) -> None:
+        """Resolve a COMPLETED job by fetching its result."""
+        try:
+            result = self._fetch_result(task_dir)
+        except (OSError, pickle.UnpicklingError) as exc:
+            future.set_exception(
+                RemoteJobError(
+                    f"Job {job_id} completed but failed to fetch result: {exc}",
+                    job_id=job_id,
+                    exit_code=exit_code,
+                    state=state,
+                ),
+            )
+            return
+
+        if result["status"] == "ok":
+            future.set_result(result["result"])
+        else:
+            future.set_exception(
+                RemoteJobError(
+                    f"Job {job_id} raised an exception:\n"
+                    f"{result.get('tb', result.get('error', 'unknown error'))}",
+                    job_id=job_id,
+                    exit_code=exit_code,
+                    state=state,
+                ),
+            )
+
+    def _query_sacct_batch(self, job_ids: list[str]) -> dict[str, tuple[str, str]]:
+        """Return {job_id: (State, ExitCode)} for all *job_ids* via a single ``sacct`` call."""
+        cmd: list[str] = ["sacct"]
+        if self.cluster is not None:
+            cmd.append(f"-M{self.cluster}")
+        cmd.extend(["-j", ",".join(job_ids), "-n", "--format=JobID,State,ExitCode", "-P"])
+
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+        except (subprocess.CalledProcessError, FileNotFoundError) as exc:
+            logger.warning("sacct query failed: %s", exc)
+            return {}
+
+        states: dict[str, tuple[str, str]] = {}
+        for line in result.stdout.strip().splitlines():
+            parts = line.split("|")
+            if len(parts) >= 3:  # noqa: PLR2004
+                raw_id = parts[0].strip()
+                # Skip sub-steps like "12345.batch" — use parent job line only
+                if "." in raw_id:
+                    continue
+                state = parts[1].strip()
+                exit_code = parts[2].strip()
+                states[raw_id] = (state, exit_code)
+        return states
+
+    def _fetch_result(
+        self,
+        task_dir: Path,
+        retries: int = 12,
+        delay: float = 5.0,
+    ) -> dict[str, Any]:
+        """Read ``output.pkl`` from *task_dir*, waiting for SLURM sync.
+
+        After ``sacct`` reports COMPLETED, the CWD sync-back may still be
+        in progress.  Retry up to *retries* times with *delay* seconds
+        between attempts.
+        """
+        output_path = task_dir / "output.pkl"
+        for attempt in range(retries):
+            if output_path.exists():
+                with output_path.open("rb") as f:
+                    return pickle.load(f)  # noqa: S301
+            logger.debug(
+                "output.pkl not yet available (attempt %d/%d), waiting for sync...",
+                attempt + 1,
+                retries,
+            )
+            time.sleep(delay)
+        # Final attempt — raise if still missing
+        with output_path.open("rb") as f:
+            return pickle.load(f)  # noqa: S301

--- a/tests/test_cross_cluster_executor.py
+++ b/tests/test_cross_cluster_executor.py
@@ -1,0 +1,717 @@
+"""Tests for CrossClusterSlurmExecutor."""
+
+from __future__ import annotations
+
+import pickle
+import subprocess
+import threading
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from adaptive_scheduler._cross_cluster_executor import (
+    CrossClusterFuture,
+    CrossClusterSlurmExecutor,
+    RemoteJobError,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+MODULE = "adaptive_scheduler._cross_cluster_executor"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _sbatch_result(job_id: str = "12345", cluster: str | None = None) -> MagicMock:
+    """Build a mock CompletedProcess for a successful sbatch call."""
+    stdout = f"Submitted batch job {job_id}"
+    if cluster:
+        stdout += f" on cluster {cluster}"
+    result = MagicMock()
+    result.stdout = stdout
+    return result
+
+
+def _sacct_result(rows: list[str]) -> MagicMock:
+    """Build a mock CompletedProcess for a sacct call.
+
+    Each row should be a pipe-separated string like "12345|COMPLETED|0:0".
+    """
+    result = MagicMock()
+    result.stdout = "\n".join(rows) + "\n"
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def executor(tmp_path: Path) -> CrossClusterSlurmExecutor:
+    """Local-mode executor with fast polling."""
+    return CrossClusterSlurmExecutor(
+        base_dir=tmp_path / "cc-jobs",
+        poll_interval=0.01,
+    )
+
+
+@pytest.fixture
+def cluster_executor(tmp_path: Path) -> CrossClusterSlurmExecutor:
+    """Remote-cluster executor with extras."""
+    return CrossClusterSlurmExecutor(
+        cluster="ionqgcp",
+        partition="gpu",
+        python_cmd="/opt/conda/bin/python",
+        base_dir=tmp_path / "cc-jobs",
+        extra_script="source /opt/env/bin/activate",
+        extra_sbatch=["--comment=gcp-consent", "--time=10:00"],
+        poll_interval=0.01,
+    )
+
+
+@pytest.fixture
+def _mock_sbatch() -> Generator[MagicMock, None, None]:
+    """Patch subprocess.run to return a successful sbatch result."""
+    with patch(f"{MODULE}.subprocess.run", return_value=_sbatch_result()) as m:
+        yield m
+
+
+# ---------------------------------------------------------------------------
+# 1. RemoteJobError
+# ---------------------------------------------------------------------------
+
+
+class TestRemoteJobError:
+    """Tests for the RemoteJobError exception class."""
+
+    def test_attributes(self) -> None:
+        """Test that RemoteJobError stores job_id, exit_code, and state."""
+        err = RemoteJobError(
+            "boom",
+            job_id="111",
+            exit_code="1:0",
+            state="FAILED",
+        )
+        assert str(err) == "boom"
+        assert err.job_id == "111"
+        assert err.exit_code == "1:0"
+        assert err.state == "FAILED"
+
+
+# ---------------------------------------------------------------------------
+# 2. __init__
+# ---------------------------------------------------------------------------
+
+
+class TestInit:
+    """Tests for CrossClusterSlurmExecutor.__init__."""
+
+    def test_defaults(self, tmp_path: Path) -> None:
+        """Test that default parameters are set correctly."""
+        ex = CrossClusterSlurmExecutor(base_dir=tmp_path)
+        assert ex.cluster is None
+        assert ex.partition == "short"
+        assert ex.python_cmd == "python"
+        assert ex.extra_sbatch == []
+        assert ex.extra_script == ""
+        assert ex.poll_interval == 5.0
+        assert ex._pending == {}
+        assert ex._shutdown is False
+        assert ex._monitor_thread is None
+
+    def test_custom_params(self, cluster_executor: CrossClusterSlurmExecutor) -> None:
+        """Test that custom parameters are stored correctly."""
+        ex = cluster_executor
+        assert ex.cluster == "ionqgcp"
+        assert ex.partition == "gpu"
+        assert ex.python_cmd == "/opt/conda/bin/python"
+        assert ex.extra_sbatch == ["--comment=gcp-consent", "--time=10:00"]
+        assert "activate" in ex.extra_script
+
+    def test_tilde_expansion(self) -> None:
+        """Test that ~ in base_dir is expanded to the home directory."""
+        ex = CrossClusterSlurmExecutor(base_dir="~/cc-jobs")
+        assert "~" not in str(ex.base_dir)
+        assert ex.base_dir == Path.home() / "cc-jobs"
+
+
+# ---------------------------------------------------------------------------
+# 3. _make_wrapper
+# ---------------------------------------------------------------------------
+
+
+class TestMakeWrapper:
+    """Tests for the SBATCH wrapper script generation."""
+
+    def test_basic_directives(self, executor: CrossClusterSlurmExecutor) -> None:
+        """Test that the wrapper contains required SBATCH directives."""
+        wrapper = executor._make_wrapper("abcd1234efgh")
+        assert "#!/bin/bash" in wrapper
+        assert "#SBATCH --partition=short" in wrapper
+        assert "#SBATCH --job-name=cc-abcd1234" in wrapper
+        assert "#SBATCH --output=stdout.log" in wrapper
+        assert "#SBATCH --error=stderr.log" in wrapper
+
+    def test_relative_paths(self, executor: CrossClusterSlurmExecutor) -> None:
+        """Test that the wrapper uses relative paths for pkl files."""
+        wrapper = executor._make_wrapper("task0001")
+        assert "input.pkl" in wrapper
+        assert "output.pkl" in wrapper
+        # Should NOT contain absolute paths to the base_dir
+        assert str(executor.base_dir) not in wrapper
+
+    def test_extra_sbatch(self, cluster_executor: CrossClusterSlurmExecutor) -> None:
+        """Test that extra_sbatch flags appear in the wrapper."""
+        wrapper = cluster_executor._make_wrapper("task0001")
+        assert "#SBATCH --comment=gcp-consent" in wrapper
+        assert "#SBATCH --time=10:00" in wrapper
+
+    def test_extra_script(self, cluster_executor: CrossClusterSlurmExecutor) -> None:
+        """Test that extra_script content is injected into the wrapper."""
+        wrapper = cluster_executor._make_wrapper("task0001")
+        assert "source /opt/env/bin/activate" in wrapper
+
+
+# ---------------------------------------------------------------------------
+# 4. _sbatch
+# ---------------------------------------------------------------------------
+
+
+class TestSbatch:
+    """Tests for sbatch submission and output parsing."""
+
+    def test_parse_local_output(self, executor: CrossClusterSlurmExecutor, tmp_path: Path) -> None:
+        """Test parsing job ID from local sbatch output."""
+        task_dir = tmp_path / "task"
+        task_dir.mkdir()
+        with patch(f"{MODULE}.subprocess.run", return_value=_sbatch_result("99999")):
+            job_id = executor._sbatch(task_dir)
+        assert job_id == "99999"
+
+    def test_parse_multicluster_output(
+        self,
+        cluster_executor: CrossClusterSlurmExecutor,
+        tmp_path: Path,
+    ) -> None:
+        """Test parsing job ID from multi-cluster sbatch output."""
+        task_dir = tmp_path / "task"
+        task_dir.mkdir()
+        with patch(
+            f"{MODULE}.subprocess.run",
+            return_value=_sbatch_result("55555", cluster="ionqgcp"),
+        ):
+            job_id = cluster_executor._sbatch(task_dir)
+        assert job_id == "55555"
+
+    def test_unparseable_raises(self, executor: CrossClusterSlurmExecutor, tmp_path: Path) -> None:
+        """Test that unparseable sbatch output raises RuntimeError."""
+        task_dir = tmp_path / "task"
+        task_dir.mkdir()
+        bad = MagicMock()
+        bad.stdout = "Something unexpected"
+        with (
+            patch(f"{MODULE}.subprocess.run", return_value=bad),
+            pytest.raises(RuntimeError, match="Could not parse"),
+        ):
+            executor._sbatch(task_dir)
+
+    def test_subprocess_error_propagates(
+        self,
+        executor: CrossClusterSlurmExecutor,
+        tmp_path: Path,
+    ) -> None:
+        """Test that CalledProcessError from sbatch propagates."""
+        task_dir = tmp_path / "task"
+        task_dir.mkdir()
+        with (
+            patch(
+                f"{MODULE}.subprocess.run",
+                side_effect=subprocess.CalledProcessError(1, "sbatch"),
+            ),
+            pytest.raises(subprocess.CalledProcessError),
+        ):
+            executor._sbatch(task_dir)
+
+
+# ---------------------------------------------------------------------------
+# 5. submit
+# ---------------------------------------------------------------------------
+
+
+class TestSubmit:
+    """Tests for the submit method."""
+
+    @pytest.mark.usefixtures("_mock_sbatch")
+    def test_creates_files(
+        self,
+        executor: CrossClusterSlurmExecutor,
+    ) -> None:
+        """Test that submit creates input.pkl and wrapper.sh in the task directory."""
+        with patch.object(executor, "_ensure_monitor"):
+            future = executor.submit(lambda x: x, 42)
+        assert isinstance(future, CrossClusterFuture)
+        # Check that input.pkl and wrapper.sh were created
+        task_dir = next((executor.base_dir / executor._run_id).iterdir())
+        assert (task_dir / "input.pkl").exists()
+        assert (task_dir / "wrapper.sh").exists()
+
+    def test_returns_future_with_job_id(self, executor: CrossClusterSlurmExecutor) -> None:
+        """Test that submit returns a CrossClusterFuture with the correct job_id."""
+        with (
+            patch(f"{MODULE}.subprocess.run", return_value=_sbatch_result("77777")),
+            patch.object(executor, "_ensure_monitor"),
+        ):
+            future = executor.submit(lambda x: x, 1)
+        assert future.job_id == "77777"
+        assert future.cluster is None
+
+    @pytest.mark.usefixtures("_mock_sbatch")
+    def test_registers_pending(
+        self,
+        executor: CrossClusterSlurmExecutor,
+    ) -> None:
+        """Test that submit registers the job in the _pending dict."""
+        with patch.object(executor, "_ensure_monitor"):
+            future = executor.submit(lambda: None)
+        assert "12345" in executor._pending
+        assert executor._pending["12345"][0] is future
+
+    def test_raises_after_shutdown(self, executor: CrossClusterSlurmExecutor) -> None:
+        """Test that submit raises RuntimeError after shutdown."""
+        executor._shutdown = True
+        with pytest.raises(RuntimeError, match="shut-down"):
+            executor.submit(lambda: None)
+
+
+# ---------------------------------------------------------------------------
+# 6. _query_sacct_batch
+# ---------------------------------------------------------------------------
+
+
+class TestQuerySacctBatch:
+    """Tests for sacct batch querying and output parsing."""
+
+    def test_parse_output(self, executor: CrossClusterSlurmExecutor) -> None:
+        """Test parsing job states from sacct output."""
+        sacct_out = _sacct_result(["12345|COMPLETED|0:0", "67890|FAILED|1:0"])
+        with patch(f"{MODULE}.subprocess.run", return_value=sacct_out):
+            states = executor._query_sacct_batch(["12345", "67890"])
+        assert states == {
+            "12345": ("COMPLETED", "0:0"),
+            "67890": ("FAILED", "1:0"),
+        }
+
+    def test_skip_substeps(self, executor: CrossClusterSlurmExecutor) -> None:
+        """Test that sub-step lines like 12345.batch are skipped."""
+        sacct_out = _sacct_result(
+            [
+                "12345|COMPLETED|0:0",
+                "12345.batch|COMPLETED|0:0",
+                "12345.extern|COMPLETED|0:0",
+            ],
+        )
+        with patch(f"{MODULE}.subprocess.run", return_value=sacct_out):
+            states = executor._query_sacct_batch(["12345"])
+        assert len(states) == 1
+        assert "12345" in states
+
+    def test_empty_on_failure(self, executor: CrossClusterSlurmExecutor) -> None:
+        """Test that CalledProcessError returns an empty dict."""
+        with patch(
+            f"{MODULE}.subprocess.run",
+            side_effect=subprocess.CalledProcessError(1, "sacct"),
+        ):
+            states = executor._query_sacct_batch(["12345"])
+        assert states == {}
+
+    def test_empty_on_file_not_found(self, executor: CrossClusterSlurmExecutor) -> None:
+        """Test that FileNotFoundError returns an empty dict."""
+        with patch(f"{MODULE}.subprocess.run", side_effect=FileNotFoundError):
+            states = executor._query_sacct_batch(["12345"])
+        assert states == {}
+
+    def test_cluster_flag(self, cluster_executor: CrossClusterSlurmExecutor) -> None:
+        """Test that the -M flag is passed when cluster is set."""
+        sacct_out = _sacct_result(["12345|RUNNING|0:0"])
+        with patch(f"{MODULE}.subprocess.run", return_value=sacct_out) as mock_run:
+            cluster_executor._query_sacct_batch(["12345"])
+        cmd = mock_run.call_args[0][0]
+        assert "-Mionqgcp" in cmd
+
+
+# ---------------------------------------------------------------------------
+# 7. _fetch_result
+# ---------------------------------------------------------------------------
+
+
+class TestFetchResult:
+    """Tests for reading output.pkl with retry logic."""
+
+    def test_reads_pkl(self, executor: CrossClusterSlurmExecutor, tmp_path: Path) -> None:
+        """Test reading an existing output.pkl file."""
+        task_dir = tmp_path / "task"
+        task_dir.mkdir()
+        payload = {"status": "ok", "result": 42}
+        (task_dir / "output.pkl").write_bytes(pickle.dumps(payload))
+        result = executor._fetch_result(task_dir, retries=1, delay=0)
+        assert result == payload
+
+    def test_retries_until_file_appears(
+        self,
+        executor: CrossClusterSlurmExecutor,
+        tmp_path: Path,
+    ) -> None:
+        """Test that _fetch_result retries and succeeds when file appears later."""
+        task_dir = tmp_path / "task"
+        task_dir.mkdir()
+        output_path = task_dir / "output.pkl"
+        payload = {"status": "ok", "result": 99}
+
+        call_count = 0
+
+        def delayed_write(_seconds: float) -> None:
+            nonlocal call_count
+            call_count += 1
+            if call_count >= 2:
+                output_path.write_bytes(pickle.dumps(payload))
+
+        with patch(f"{MODULE}.time.sleep", side_effect=delayed_write):
+            result = executor._fetch_result(task_dir, retries=5, delay=0.01)
+        assert result["result"] == 99
+
+    def test_raises_after_retries_exhausted(
+        self,
+        executor: CrossClusterSlurmExecutor,
+        tmp_path: Path,
+    ) -> None:
+        """Test that FileNotFoundError is raised when retries are exhausted."""
+        task_dir = tmp_path / "task"
+        task_dir.mkdir()
+        with (
+            patch(f"{MODULE}.time.sleep"),
+            pytest.raises(FileNotFoundError),
+        ):
+            executor._fetch_result(task_dir, retries=2, delay=0)
+
+
+# ---------------------------------------------------------------------------
+# 8. _monitor
+# ---------------------------------------------------------------------------
+
+
+class TestMonitor:
+    """Tests for the background monitor thread logic."""
+
+    def _run_monitor_once(self, executor: CrossClusterSlurmExecutor) -> None:
+        """Set _shutdown so the monitor exits after processing pending jobs."""
+        executor._shutdown = True
+        with patch(f"{MODULE}.time.sleep"):
+            executor._monitor()
+
+    def test_resolves_completed(self, executor: CrossClusterSlurmExecutor, tmp_path: Path) -> None:
+        """Test that a COMPLETED job resolves the future with the result."""
+        task_dir = tmp_path / "task"
+        task_dir.mkdir()
+        payload = {"status": "ok", "result": 42}
+        (task_dir / "output.pkl").write_bytes(pickle.dumps(payload))
+
+        future = CrossClusterFuture(job_id="100", cluster=None)
+        executor._pending["100"] = (future, task_dir)
+
+        sacct_out = _sacct_result(["100|COMPLETED|0:0"])
+        with patch(f"{MODULE}.subprocess.run", return_value=sacct_out):
+            self._run_monitor_once(executor)
+
+        assert future.result() == 42
+
+    def test_sets_error_on_failed(
+        self,
+        executor: CrossClusterSlurmExecutor,
+        tmp_path: Path,
+    ) -> None:
+        """Test that a FAILED job sets RemoteJobError on the future."""
+        task_dir = tmp_path / "task"
+        task_dir.mkdir()
+
+        future = CrossClusterFuture(job_id="200", cluster=None)
+        executor._pending["200"] = (future, task_dir)
+
+        sacct_out = _sacct_result(["200|FAILED|1:0"])
+        with patch(f"{MODULE}.subprocess.run", return_value=sacct_out):
+            self._run_monitor_once(executor)
+
+        with pytest.raises(RemoteJobError, match="state=FAILED"):
+            future.result()
+        exc = future.exception()
+        assert isinstance(exc, RemoteJobError)
+        assert exc.job_id == "200"
+        assert exc.state == "FAILED"
+
+    def test_handles_remote_python_error(
+        self,
+        executor: CrossClusterSlurmExecutor,
+        tmp_path: Path,
+    ) -> None:
+        """Test that a remote Python exception is wrapped in RemoteJobError."""
+        task_dir = tmp_path / "task"
+        task_dir.mkdir()
+        payload = {"status": "error", "error": "ZeroDivisionError", "tb": "Traceback..."}
+        (task_dir / "output.pkl").write_bytes(pickle.dumps(payload))
+
+        future = CrossClusterFuture(job_id="300", cluster=None)
+        executor._pending["300"] = (future, task_dir)
+
+        sacct_out = _sacct_result(["300|COMPLETED|0:0"])
+        with patch(f"{MODULE}.subprocess.run", return_value=sacct_out):
+            self._run_monitor_once(executor)
+
+        with pytest.raises(RemoteJobError, match="Traceback"):
+            future.result()
+
+    def test_skips_running_and_pending(
+        self,
+        executor: CrossClusterSlurmExecutor,
+        tmp_path: Path,
+    ) -> None:
+        """Test that RUNNING and PENDING jobs are not resolved."""
+        task_dir = tmp_path / "task"
+        task_dir.mkdir()
+
+        future_r = CrossClusterFuture(job_id="400", cluster=None)
+        future_p = CrossClusterFuture(job_id="401", cluster=None)
+        executor._pending["400"] = (future_r, task_dir)
+        executor._pending["401"] = (future_p, task_dir)
+
+        sacct_out = _sacct_result(["400|RUNNING|0:0", "401|PENDING|0:0"])
+        # Monitor must exit even with pending jobs when _shutdown=True and
+        # pending remains. We simulate two iterations: first returns RUNNING/PENDING,
+        # second we let shutdown take effect by clearing pending.
+        call_count = 0
+
+        def fake_sleep(_: float) -> None:
+            nonlocal call_count
+            call_count += 1
+            if call_count >= 1:
+                # After first sleep, remove pending so monitor exits
+                with executor._lock:
+                    executor._pending.clear()
+
+        executor._shutdown = True
+        with (
+            patch(f"{MODULE}.subprocess.run", return_value=sacct_out),
+            patch(f"{MODULE}.time.sleep", side_effect=fake_sleep),
+        ):
+            executor._monitor()
+
+        # Futures should still be unresolved
+        assert not future_r.done()
+        assert not future_p.done()
+
+    def test_exits_on_shutdown_no_pending(self, executor: CrossClusterSlurmExecutor) -> None:
+        """Test that the monitor exits immediately when shutdown with no pending jobs."""
+        executor._shutdown = True
+        # No pending jobs — monitor should return immediately
+        with patch(f"{MODULE}.time.sleep"):
+            executor._monitor()
+
+    def test_handles_fetch_failure(
+        self,
+        executor: CrossClusterSlurmExecutor,
+        tmp_path: Path,
+    ) -> None:
+        """Test that a fetch failure on COMPLETED job sets RemoteJobError."""
+        task_dir = tmp_path / "task"
+        task_dir.mkdir()
+        # No output.pkl — _fetch_result will fail
+
+        future = CrossClusterFuture(job_id="500", cluster=None)
+        executor._pending["500"] = (future, task_dir)
+
+        sacct_out = _sacct_result(["500|COMPLETED|0:0"])
+        with (
+            patch(f"{MODULE}.subprocess.run", return_value=sacct_out),
+            patch(f"{MODULE}.time.sleep"),
+        ):
+            # _fetch_result will raise since no output.pkl; monitor should catch it
+            executor._shutdown = True
+            executor._monitor()
+
+        with pytest.raises(RemoteJobError, match="failed to fetch result"):
+            future.result()
+
+
+# ---------------------------------------------------------------------------
+# 9. CrossClusterFuture.cancel
+# ---------------------------------------------------------------------------
+
+
+class TestCrossClusterFutureCancel:
+    """Tests for CrossClusterFuture.cancel via scancel."""
+
+    def test_cancel_with_cluster(self) -> None:
+        """Test that cancel passes -M flag when cluster is set."""
+        future = CrossClusterFuture(job_id="111", cluster="ionqgcp")
+        with patch(f"{MODULE}.subprocess.run") as mock_run:
+            result = future.cancel()
+        assert result is True
+        cmd = mock_run.call_args[0][0]
+        assert cmd == ["scancel", "-Mionqgcp", "111"]
+
+    def test_cancel_without_cluster(self) -> None:
+        """Test that cancel omits -M flag for local cluster."""
+        future = CrossClusterFuture(job_id="222", cluster=None)
+        with patch(f"{MODULE}.subprocess.run") as mock_run:
+            result = future.cancel()
+        assert result is True
+        cmd = mock_run.call_args[0][0]
+        assert cmd == ["scancel", "222"]
+
+    def test_returns_false_when_done(self) -> None:
+        """Test that cancel returns False when the future is already done."""
+        future = CrossClusterFuture(job_id="333", cluster=None)
+        future.set_result(42)
+        result = future.cancel()
+        assert result is False
+
+    def test_returns_false_on_subprocess_failure(self) -> None:
+        """Test that cancel returns False when scancel fails."""
+        future = CrossClusterFuture(job_id="444", cluster=None)
+        with patch(
+            f"{MODULE}.subprocess.run",
+            side_effect=subprocess.CalledProcessError(1, "scancel"),
+        ):
+            result = future.cancel()
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# 10. shutdown
+# ---------------------------------------------------------------------------
+
+
+class TestShutdown:
+    """Tests for executor shutdown behavior."""
+
+    def test_sets_flag(self, executor: CrossClusterSlurmExecutor) -> None:
+        """Test that shutdown sets the _shutdown flag."""
+        executor.shutdown(wait=False)
+        assert executor._shutdown is True
+
+    def test_cancel_futures_calls_cancel(
+        self,
+        executor: CrossClusterSlurmExecutor,
+        tmp_path: Path,
+    ) -> None:
+        """Test that shutdown with cancel_futures cancels pending jobs."""
+        future = CrossClusterFuture(job_id="555", cluster=None)
+        executor._pending["555"] = (future, tmp_path)
+        with patch(f"{MODULE}.subprocess.run"):
+            executor.shutdown(wait=False, cancel_futures=True)
+        assert future.cancelled()
+
+    def test_wait_joins_thread(self, executor: CrossClusterSlurmExecutor) -> None:
+        """Test that shutdown with wait=True joins the monitor thread."""
+        mock_thread = MagicMock(spec=threading.Thread)
+        executor._monitor_thread = mock_thread
+        executor.shutdown(wait=True)
+        mock_thread.join.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# 11. Context manager
+# ---------------------------------------------------------------------------
+
+
+class TestContextManager:
+    """Tests for the context manager protocol."""
+
+    def test_enter_returns_self(self, executor: CrossClusterSlurmExecutor) -> None:
+        """Test that __enter__ returns the executor instance."""
+        with patch.object(executor, "shutdown"), executor as ex:
+            assert ex is executor
+
+    def test_exit_calls_shutdown(self, executor: CrossClusterSlurmExecutor) -> None:
+        """Test that __exit__ calls shutdown(wait=True)."""
+        with patch.object(executor, "shutdown") as mock_shutdown, executor:
+            pass
+        mock_shutdown.assert_called_once_with(wait=True)
+
+
+# ---------------------------------------------------------------------------
+# 12. End-to-end (mocked subprocess, real threads)
+# ---------------------------------------------------------------------------
+
+
+class TestEndToEnd:
+    """End-to-end tests with real monitor threads and mocked subprocess calls."""
+
+    def test_submit_then_resolve_local(self, executor: CrossClusterSlurmExecutor) -> None:
+        """Submit a job, have sacct report COMPLETED, and verify the future resolves."""
+
+        def fake_subprocess_run(cmd: list[str], **kwargs: Any) -> MagicMock:
+            if cmd[0] == "sbatch":
+                # Write output.pkl atomically in the sbatch mock to avoid
+                # a race with the monitor thread that starts immediately.
+                cwd = kwargs.get("cwd")
+                if cwd is not None:
+                    payload = {"status": "ok", "result": 42}
+                    Path(cwd, "output.pkl").write_bytes(pickle.dumps(payload))
+                return _sbatch_result("90001")
+            if cmd[0] == "sacct":
+                return _sacct_result(["90001|COMPLETED|0:0"])
+            msg = f"Unexpected command: {cmd}"
+            raise ValueError(msg)
+
+        with (
+            patch(f"{MODULE}.subprocess.run", side_effect=fake_subprocess_run),
+            patch(f"{MODULE}.time.sleep"),
+        ):
+            future = executor.submit(lambda x: x * 2, 21)
+            result = future.result(timeout=5)
+
+        assert result == 42
+        executor.shutdown(wait=False)
+
+    def test_submit_then_resolve_cluster(
+        self,
+        cluster_executor: CrossClusterSlurmExecutor,
+    ) -> None:
+        """Same as above but with cluster mode — verifies -M flags are passed."""
+        cmds_seen: list[list[str]] = []
+
+        def fake_subprocess_run(cmd: list[str], **kwargs: Any) -> MagicMock:
+            cmds_seen.append(list(cmd))
+            if cmd[0] == "sbatch":
+                cwd = kwargs.get("cwd")
+                if cwd is not None:
+                    payload = {"status": "ok", "result": 10}
+                    Path(cwd, "output.pkl").write_bytes(pickle.dumps(payload))
+                return _sbatch_result("90002", cluster="ionqgcp")
+            if cmd[0] == "sacct":
+                return _sacct_result(["90002|COMPLETED|0:0"])
+            msg = f"Unexpected command: {cmd}"
+            raise ValueError(msg)
+
+        with (
+            patch(f"{MODULE}.subprocess.run", side_effect=fake_subprocess_run),
+            patch(f"{MODULE}.time.sleep"),
+        ):
+            future = cluster_executor.submit(lambda x: x + 1, 9)
+            result = future.result(timeout=5)
+
+        assert result == 10
+
+        # Verify -M flag was used for both sbatch and sacct
+        sbatch_cmds = [c for c in cmds_seen if c[0] == "sbatch"]
+        sacct_cmds = [c for c in cmds_seen if c[0] == "sacct"]
+        assert any("-Mionqgcp" in c for c in sbatch_cmds)
+        assert any("-Mionqgcp" in c for c in sacct_cmds)
+
+        cluster_executor.shutdown(wait=False)

--- a/tests/test_cross_cluster_executor.py
+++ b/tests/test_cross_cluster_executor.py
@@ -616,7 +616,8 @@ class TestMonitor:
         sacct_calls: list[tuple[list[str], str | None]] = []
 
         def tracking_sacct(
-            job_ids: list[str], cluster: str | None = None
+            job_ids: list[str],
+            cluster: str | None = None,
         ) -> dict[str, tuple[str, str]]:
             sacct_calls.append((job_ids, cluster))
             return dict.fromkeys(job_ids, ("RUNNING", "0:0"))
@@ -890,7 +891,9 @@ class TestRetryLogic:
         future = CrossClusterFuture(job_id="100", cluster=None)
         retry_executor._pending["100"] = (future, task_dir)
 
-        def fake_sacct(job_ids: list[str], cluster: str | None = None) -> dict[str, tuple[str, str]]:
+        def fake_sacct(
+            job_ids: list[str], cluster: str | None = None
+        ) -> dict[str, tuple[str, str]]:
             result: dict[str, tuple[str, str]] = {}
             for jid in job_ids:
                 if jid == "100":
@@ -930,7 +933,9 @@ class TestRetryLogic:
         future = CrossClusterFuture(job_id="200", cluster=None)
         retry_executor._pending["200"] = (future, task_dir)
 
-        def fake_sacct(job_ids: list[str], cluster: str | None = None) -> dict[str, tuple[str, str]]:
+        def fake_sacct(
+            job_ids: list[str], cluster: str | None = None
+        ) -> dict[str, tuple[str, str]]:
             result: dict[str, tuple[str, str]] = {}
             for jid in job_ids:
                 if jid == "200":
@@ -1018,8 +1023,10 @@ class TestRetryLogic:
 
         sbatch_count = 0
 
-        def fake_sacct(job_ids: list[str], cluster: str | None = None) -> dict[str, tuple[str, str]]:
-            return {jid: ("NODE_FAIL", "9:0") for jid in job_ids}
+        def fake_sacct(
+            job_ids: list[str], cluster: str | None = None
+        ) -> dict[str, tuple[str, str]]:
+            return dict.fromkeys(job_ids, ("NODE_FAIL", "9:0"))
 
         def fake_sbatch(task_dir: Path) -> tuple[str, str | None]:
             nonlocal sbatch_count
@@ -1174,7 +1181,7 @@ class TestRetryLogic:
 
     def test_retryable_states_constant(self) -> None:
         """RETRYABLE_STATES contains exactly NODE_FAIL and PREEMPTED."""
-        assert RETRYABLE_STATES == frozenset({"NODE_FAIL", "PREEMPTED"})
+        assert frozenset({"NODE_FAIL", "PREEMPTED"}) == RETRYABLE_STATES
 
     def test_max_retries_stored(self, tmp_path: Path) -> None:
         """max_retries parameter is stored on the executor."""

--- a/tests/test_cross_cluster_executor.py
+++ b/tests/test_cross_cluster_executor.py
@@ -892,7 +892,8 @@ class TestRetryLogic:
         retry_executor._pending["100"] = (future, task_dir)
 
         def fake_sacct(
-            job_ids: list[str], cluster: str | None = None
+            job_ids: list[str],
+            cluster: str | None = None,
         ) -> dict[str, tuple[str, str]]:
             result: dict[str, tuple[str, str]] = {}
             for jid in job_ids:
@@ -934,7 +935,8 @@ class TestRetryLogic:
         retry_executor._pending["200"] = (future, task_dir)
 
         def fake_sacct(
-            job_ids: list[str], cluster: str | None = None
+            job_ids: list[str],
+            cluster: str | None = None,
         ) -> dict[str, tuple[str, str]]:
             result: dict[str, tuple[str, str]] = {}
             for jid in job_ids:
@@ -1024,7 +1026,8 @@ class TestRetryLogic:
         sbatch_count = 0
 
         def fake_sacct(
-            job_ids: list[str], cluster: str | None = None
+            job_ids: list[str],
+            cluster: str | None = None,
         ) -> dict[str, tuple[str, str]]:
             return dict.fromkeys(job_ids, ("NODE_FAIL", "9:0"))
 

--- a/tests/test_cross_cluster_executor.py
+++ b/tests/test_cross_cluster_executor.py
@@ -614,7 +614,9 @@ class TestMonitor:
 
         sacct_calls: list[tuple[list[str], str | None]] = []
 
-        def tracking_sacct(job_ids: list[str], cluster: str | None = None) -> dict[str, tuple[str, str]]:
+        def tracking_sacct(
+            job_ids: list[str], cluster: str | None = None
+        ) -> dict[str, tuple[str, str]]:
             sacct_calls.append((job_ids, cluster))
             return dict.fromkeys(job_ids, ("RUNNING", "0:0"))
 

--- a/tests/test_cross_cluster_executor.py
+++ b/tests/test_cross_cluster_executor.py
@@ -893,7 +893,7 @@ class TestRetryLogic:
 
         def fake_sacct(
             job_ids: list[str],
-            _cluster: str | None = None,
+            cluster: str | None = None,  # noqa: ARG001
         ) -> dict[str, tuple[str, str]]:
             result: dict[str, tuple[str, str]] = {}
             for jid in job_ids:
@@ -936,7 +936,7 @@ class TestRetryLogic:
 
         def fake_sacct(
             job_ids: list[str],
-            _cluster: str | None = None,
+            cluster: str | None = None,  # noqa: ARG001
         ) -> dict[str, tuple[str, str]]:
             result: dict[str, tuple[str, str]] = {}
             for jid in job_ids:
@@ -1027,7 +1027,7 @@ class TestRetryLogic:
 
         def fake_sacct(
             job_ids: list[str],
-            _cluster: str | None = None,
+            cluster: str | None = None,  # noqa: ARG001
         ) -> dict[str, tuple[str, str]]:
             return dict.fromkeys(job_ids, ("NODE_FAIL", "9:0"))
 

--- a/tests/test_cross_cluster_executor.py
+++ b/tests/test_cross_cluster_executor.py
@@ -893,7 +893,7 @@ class TestRetryLogic:
 
         def fake_sacct(
             job_ids: list[str],
-            cluster: str | None = None,
+            _cluster: str | None = None,
         ) -> dict[str, tuple[str, str]]:
             result: dict[str, tuple[str, str]] = {}
             for jid in job_ids:
@@ -903,7 +903,7 @@ class TestRetryLogic:
                     result[jid] = ("COMPLETED", "0:0")
             return result
 
-        def fake_sbatch(task_dir: Path) -> tuple[str, str | None]:
+        def fake_sbatch(_task_dir: Path) -> tuple[str, str | None]:
             return ("101", None)
 
         payload = {"status": "ok", "result": 42}
@@ -936,7 +936,7 @@ class TestRetryLogic:
 
         def fake_sacct(
             job_ids: list[str],
-            cluster: str | None = None,
+            _cluster: str | None = None,
         ) -> dict[str, tuple[str, str]]:
             result: dict[str, tuple[str, str]] = {}
             for jid in job_ids:
@@ -946,7 +946,7 @@ class TestRetryLogic:
                     result[jid] = ("COMPLETED", "0:0")
             return result
 
-        def fake_sbatch(task_dir: Path) -> tuple[str, str | None]:
+        def fake_sbatch(_task_dir: Path) -> tuple[str, str | None]:
             return ("201", None)
 
         payload = {"status": "ok", "result": 99}
@@ -1027,11 +1027,11 @@ class TestRetryLogic:
 
         def fake_sacct(
             job_ids: list[str],
-            cluster: str | None = None,
+            _cluster: str | None = None,
         ) -> dict[str, tuple[str, str]]:
             return dict.fromkeys(job_ids, ("NODE_FAIL", "9:0"))
 
-        def fake_sbatch(task_dir: Path) -> tuple[str, str | None]:
+        def fake_sbatch(_task_dir: Path) -> tuple[str, str | None]:
             nonlocal sbatch_count
             sbatch_count += 1
             return (f"50{sbatch_count}", None)
@@ -1119,7 +1119,7 @@ class TestRetryLogic:
         assert future.cluster is None
         assert future.attempts == 1
 
-        def fake_sbatch(td: Path) -> tuple[str, str | None]:
+        def fake_sbatch(_td: Path) -> tuple[str, str | None]:
             return ("801", "ionqgcp")
 
         with patch.object(retry_executor, "_sbatch", side_effect=fake_sbatch):


### PR DESCRIPTION
## Summary
- Proof-of-concept `CrossClusterSlurmExecutor` — a `concurrent.futures.Executor` that submits jobs across SLURM multi-cluster without a shared filesystem
- Uses `sbatch -M` for submission, `sacct -M` for monitoring, and SLURM's built-in CWD sync for file transfer
- Tested on obsidian (local) and obsidian → ionqgcp (cross-cluster)
- **60 unit tests** with **99% code coverage** (all subprocess calls mocked — no real SLURM needed)

## How it works
- Creates a local task directory, pickles the callable into `input.pkl`, generates a `wrapper.sh` with relative paths
- Runs `sbatch` from the task directory so SLURM's CWD sync transfers files to the remote cluster
- A daemon thread polls `sacct` (batching all job IDs into one call) and resolves futures
- Retries result retrieval to handle the race between `sacct` reporting COMPLETED and the sync-back finishing

## Retry logic for transient SLURM failures
- New `max_retries` parameter (default `0` — no retries, preserving existing behavior)
- Automatically retries jobs that fail with `NODE_FAIL` or `PREEMPTED` states (common on cloud clusters due to node crashes and preemptions)
- Non-retryable failures (`FAILED`, `TIMEOUT`, `OOM`, etc.) still raise `RemoteJobError` immediately
- On retry: cleans stale output files, re-submits via `sbatch`, updates the future's `job_id`/`cluster`/`attempts`
- Error messages include attempt count when retries were exhausted (e.g. "after 2 attempt(s)")

## Files changed
- `adaptive_scheduler/_cross_cluster_executor.py` — executor implementation (~540 lines)
- `tests/test_cross_cluster_executor.py` — 60 tests across 13 test groups (~1190 lines)
- `adaptive_scheduler/__init__.py` — public exports
- `README.md` — usage docs

## Test coverage
- `RemoteJobError` — attributes stored correctly
- `__init__` — defaults, custom params, `~` expansion
- `_make_wrapper` — SBATCH directives, relative paths, extra_sbatch/extra_script
- `_sbatch` — parse local/multi-cluster output, error handling
- `submit` — creates files, returns future, registers pending, rejects after shutdown
- `_query_sacct_batch` — parse output, skip substeps, error handling, `-M` flag
- `_fetch_result` — reads pkl, retries until file appears, raises after retries exhausted
- `_monitor` — resolves COMPLETED, sets error on FAILED, handles remote python errors, skips RUNNING/PENDING, exits on shutdown
- `CrossClusterFuture.cancel` — scancel with/without `-M`, edge cases
- `shutdown` / context manager — flag setting, cancel_futures, wait/join
- End-to-end — submit → monitor → resolve (local and cluster modes)
- **Retry logic** — retry on NODE_FAIL/PREEMPTED, no retry on FAILED/Python errors, retries exhausted, stale file cleanup, future job_id updates, end-to-end retry flow

## Next steps
- Support different sbatch workflows
- Integration with `pipefunc.Pipeline.map_async`

## Test plan
- [x] Local test on obsidian (`cluster=None`, partition `short`)
- [x] Cross-cluster test obsidian → ionqgcp (`cluster="ionqgcp"`, partition `c4dh8`)
- [x] Unit tests (60/60 passing on Python 3.10, 3.11, 3.12)
- [ ] Integration with `pipefunc.Pipeline.map_async`
