### PR TITLE
Get cores per partition from sinfo instead of parsing the partition name

### DIFF
--- a/adaptive_scheduler/_scheduler/slurm.py
+++ b/adaptive_scheduler/_scheduler/slurm.py
@@ -542,9 +542,12 @@ def slurm_partitions(
     try:
         # Try with -M all first to include partitions from all clusters in a
         # federation. Falls back to local-only if slurmdbd is not available.
+        # Explicit field widths prevent long partition names from running
+        # into the CPUs column (the default width is 20 characters).
+        fmt = "Partition:100,CPUs:25"
         for cmd in [
-            ["sinfo", "-ahO", "Partition,CPUs", "-M", "all"],
-            ["sinfo", "-ahO", "Partition,CPUs"],
+            ["sinfo", "-ahO", fmt, "-M", "all"],
+            ["sinfo", "-ahO", fmt],
         ]:
             output = subprocess.run(
                 cmd,

--- a/adaptive_scheduler/_scheduler/slurm.py
+++ b/adaptive_scheduler/_scheduler/slurm.py
@@ -525,11 +525,11 @@ class SLURM(BaseScheduler):
             print(f"No running jobs found with name pattern '{name}-<integer>'")
 
 
-def _get_ncores(partition: str) -> int | None:
-    numbers = re.findall(r"\d+", partition)
-    if not numbers:
-        return None
-    return int(numbers[0])
+def _parse_ncores(value: str) -> int | None:
+    # The CPUS column may show e.g. ``32+`` when nodes in a partition
+    # have different CPU counts; take the leading number.
+    match = re.match(r"\d+", value)
+    return int(match.group()) if match else None
 
 
 @lru_cache(maxsize=1)
@@ -543,8 +543,8 @@ def slurm_partitions(
         # Try with -M all first to include partitions from all clusters in a
         # federation. Falls back to local-only if slurmdbd is not available.
         for cmd in [
-            ["sinfo", "-ahO", "partition", "-M", "all"],
-            ["sinfo", "-ahO", "partition"],
+            ["sinfo", "-ahO", "Partition,CPUs", "-M", "all"],
+            ["sinfo", "-ahO", "Partition,CPUs"],
         ]:
             output = subprocess.run(
                 cmd,
@@ -557,16 +557,29 @@ def slurm_partitions(
     except FileNotFoundError:
         return {} if with_ncores else []
     lines = output.stdout.decode("utf-8").split("\n")
-    partitions = sorted(partition for line in lines if (partition := line.strip()))
-    # Sort partitions alphabetically, but put the default partition first
-    partitions = sorted(partitions, key=lambda s: ("*" not in s, s))
-    # Remove asterisk, which is used for default partition, and deduplicate
-    # (partitions may appear multiple times when querying a federation)
-    partitions = list(dict.fromkeys(p.replace("*", "") for p in partitions))
+    entries = []
+    for line in lines:
+        fields = line.split()
+        if not fields or fields[0] == "CLUSTER:":  # -M all prints a header per cluster
+            continue
+        ncores = _parse_ncores(fields[1]) if len(fields) > 1 else None
+        entries.append((fields[0], ncores))
+    # Sort partitions alphabetically, but put the default partition
+    # (marked with an asterisk) first
+    entries.sort(key=lambda e: ("*" not in e[0], e[0]))
+    # Remove the asterisk and merge duplicates: a partition appears multiple
+    # times when querying a federation or when it contains nodes with
+    # different CPU counts, in which case we keep the largest count.
+    ncores_per_partition: dict[str, int | None] = {}
+    for partition, ncores in entries:
+        name = partition.replace("*", "")
+        current = ncores_per_partition.get(name)
+        if current is None or (ncores is not None and ncores > current):
+            ncores_per_partition[name] = ncores
     if not with_ncores:
-        return partitions
+        return list(ncores_per_partition)
 
-    return {partition: _get_ncores(partition) for partition in partitions}
+    return ncores_per_partition
 
 
 def _cores(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -119,7 +119,12 @@ def job_manager(
 @pytest.fixture
 def _mock_slurm_partitions_output() -> Generator[None, None, None]:
     """Mock `slurm_partitions` function."""
-    mock_output = "hb120v2-low\nhb60-high\nnc24-low*\nnd40v2-mpi\n"
+    mock_output = (
+        "hb120v2-low         120\n"
+        "hb60-high           60\n"
+        "nc24-low*           24\n"
+        "nd40v2-mpi          40\n"
+    )
     with patch("adaptive_scheduler._scheduler.slurm.subprocess.run") as mock_run:
         mock_run.return_value = MagicMock(stdout=mock_output.encode("utf-8"))
         yield

--- a/tests/test_slurm_scheduler.py
+++ b/tests/test_slurm_scheduler.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import textwrap
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -160,6 +160,25 @@ def test_slurm_partitions() -> None:
     ]
     partitions = adaptive_scheduler._scheduler.slurm.slurm_partitions(with_ncores=True)
     assert partitions == PARTITIONS
+
+
+def test_slurm_partitions_without_ncores_in_name() -> None:
+    """The number of cores comes from the CPUs column, not the partition name."""
+    mock_output = (
+        "CLUSTER: cluster1\n"
+        "compute*            64\n"
+        "gpu                 128\n"
+        "gpu                 96\n"
+        "bigmem              32+\n"
+    )
+    slurm_partitions = adaptive_scheduler._scheduler.slurm.slurm_partitions
+    with patch("adaptive_scheduler._scheduler.slurm.subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(stdout=mock_output.encode("utf-8"))
+        slurm_partitions.cache_clear()
+        partitions = slurm_partitions(timeout=42)
+    slurm_partitions.cache_clear()
+    assert partitions == {"compute": 64, "gpu": 128, "bigmem": 32}
+    assert list(partitions) == ["compute", "bigmem", "gpu"]  # default partition first
 
 
 @pytest.mark.usefixtures("_mock_slurm_partitions")


### PR DESCRIPTION
## Problem

`slurm_partitions()` determined the number of cores per partition by taking the first number appearing in the partition name (e.g., `hb120v2-low` → 120). On clusters whose partition names don't encode the CPU count (we recently renamed ours), this returns wrong values or `None`, breaking the automatic `cores_per_node` detection in `slurm_run` and the core capping in the ipyparallel job script.

## Solution

Ask SLURM directly: `sinfo -h -O "Partition,CPUs"` reports the CPUs per node for every partition in one call, so no name parsing is needed. The `-M all` federation fallback from #304 is preserved.

Details:
- A partition with heterogeneous nodes produces one line per node group (and `sinfo` may report e.g. `32+`); the largest count is kept.
- `CLUSTER:` header lines emitted by `sinfo -M all` are skipped (previously these could leak into the partition list).
- Explicit field widths (`Partition:100,CPUs:25`) prevent partition names ≥20 characters from running into the CPUs column (`-O` defaults to 20-character fields with no separator on overflow).
- `_get_ncores` (name parsing) is removed.

Version compatibility: no change to the minimum supported Slurm. The previous code already required `-O`/`--Format` (Slurm 14.03+), and the `partition`/`cpus` fields and `type:size` width syntax are documented at least as far back as the 15.08 man page.

## Testing

- Updated the `_mock_slurm_partitions_output` fixture to the new two-column output.
- Added `test_slurm_partitions_without_ncores_in_name` covering number-free partition names, duplicate heterogeneous entries, the `32+` notation, `CLUSTER:` lines, and default-partition-first ordering.