### PR TITLE
Fix RuntimeError from asyncio.get_event_loop when no loop is set

### DIFF
--- a/adaptive_scheduler/_mock_scheduler.py
+++ b/adaptive_scheduler/_mock_scheduler.py
@@ -14,6 +14,8 @@ import zmq
 import zmq.asyncio
 from toolz.dicttoolz import dissoc
 
+from adaptive_scheduler.utils import _get_event_loop
+
 if TYPE_CHECKING:
     from collections.abc import Coroutine
     from typing import Any
@@ -71,7 +73,7 @@ class MockScheduler:
         self.startup_delay = startup_delay
         self.refresh_interval = refresh_interval
         self.bash = bash
-        self.ioloop = asyncio.get_event_loop()
+        self.ioloop = _get_event_loop()
         self.refresh_task = self.ioloop.create_task(self._refresh_coro())
         self.url = url or DEFAULT_URL
         self.command_listener_task = self.ioloop.create_task(self._command_listener())
@@ -198,7 +200,7 @@ def _external_command(command: tuple[str, ...], url: str) -> Any:
             return await socket.recv_pyobj()
 
     coro = _coro(command, url)
-    ioloop = asyncio.get_event_loop()
+    ioloop = _get_event_loop()
     task = ioloop.create_task(coro)
     return ioloop.run_until_complete(task)
 

--- a/adaptive_scheduler/_server_support/base_manager.py
+++ b/adaptive_scheduler/_server_support/base_manager.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import abc
-import asyncio
 from typing import TYPE_CHECKING
 
+from adaptive_scheduler.utils import _get_event_loop
+
 if TYPE_CHECKING:
+    import asyncio
     from collections.abc import Coroutine
 
 
@@ -23,7 +25,7 @@ class BaseManager(metaclass=abc.ABCMeta):
             msg = f"{self.__class__} is already started!"
             raise ManagerAlreadyStartedError(msg)
         self._setup()
-        self.ioloop = asyncio.get_event_loop()
+        self.ioloop = _get_event_loop()
         self._coro = self._manage()
         self.task = self.ioloop.create_task(self._coro)
         return self

--- a/adaptive_scheduler/_server_support/common.py
+++ b/adaptive_scheduler/_server_support/common.py
@@ -17,6 +17,7 @@ import zmq.ssh
 from rich.console import Console
 
 from adaptive_scheduler.utils import (
+    _get_event_loop,
     _progress,
     _remove_or_move_files,
 )
@@ -177,7 +178,7 @@ def periodically_clean_ipython_profiles(
                 _delete_old_ipython_profiles(scheduler, with_progress_bar=False)
             await asyncio.sleep(interval)
 
-    ioloop = asyncio.get_event_loop()
+    ioloop = _get_event_loop()
     coro = clean(interval)
     return ioloop.create_task(coro)
 

--- a/adaptive_scheduler/utils.py
+++ b/adaptive_scheduler/utils.py
@@ -79,6 +79,30 @@ EXECUTOR_TYPES = Literal[
 GoalTypes = Callable[[adaptive.BaseLearner], bool] | int | float | datetime | timedelta | None
 
 
+def _get_event_loop() -> asyncio.AbstractEventLoop:
+    """Get the event loop on which to schedule tasks from synchronous code.
+
+    Unlike `asyncio.get_event_loop`, this creates and sets a new event loop
+    if there is none: implicit creation was deprecated in Python 3.12 and
+    removed in 3.14, and e.g. ``pytest-asyncio>=1.4`` unsets the loop after
+    running async tests, in both cases making `asyncio.get_event_loop` raise
+    a `RuntimeError`.
+    """
+    try:
+        return asyncio.get_running_loop()
+    except RuntimeError:  # not inside a running event loop (e.g., not in Jupyter)
+        pass
+    try:
+        loop = asyncio.get_event_loop()
+        if not loop.is_closed():
+            return loop
+    except RuntimeError:  # no event loop is set for this thread
+        pass
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    return loop
+
+
 def shuffle_list(*lists: list, seed: int | None = 0) -> zip:
     """Shuffle multiple lists in the same order."""
     combined = list(zip(*lists, strict=True))
@@ -1379,7 +1403,7 @@ def track_file_creation_progress(
     columns = (*Progress.get_default_columns(), TimeElapsedColumn())
     progress = Progress(*columns, auto_refresh=False)
     coro = _track_file_creation_progress(paths_dict, progress, interval)
-    ioloop = asyncio.get_event_loop()
+    ioloop = _get_event_loop()
     return ioloop.create_task(coro)
 
 


### PR DESCRIPTION
## Problem

The pytest workflow has failed on **every PR since June 3** (including unrelated Renovate and pre-commit-autoupdate branches) with:

```
RuntimeError: There is no current event loop in thread 'MainThread'.
```

in 24 tests across `test_log_parsing.py` and `test_run_manager.py`.

**Root cause:** the unpinned conda environment picked up **pytest-asyncio 1.4.0** (last green run on June 1 had 1.3.0). pytest-asyncio 1.4 no longer leaves an event loop set on the main thread after running async tests, so any later *synchronous* call to `asyncio.get_event_loop()` raises. The codebase had five such call sites (`BaseManager.start`, `MockScheduler.__init__`, `_external_command`, `periodically_clean_ipython_profiles`, `track_file_creation_progress`).

This was a latent bug, not just a test issue: Python 3.12 deprecated implicit loop creation in `asyncio.get_event_loop()` and **Python 3.14 removed it**, so the same `RuntimeError` occurs on 3.14 in any plain (non-Jupyter) script.

## Solution

Add `_get_event_loop()` in `utils.py`, used at all five call sites. It returns, in order of preference:
1. the running loop (e.g., inside Jupyter/ipykernel) — the common production path, unchanged;
2. the loop already set for the thread, if any and not closed — keeps multiple `Manager.start()` calls on the same loop;
3. a newly created loop, which it also sets for the thread so subsequent calls reuse it.

## Testing

On Python 3.14 (where `get_event_loop` no longer creates loops, reproducing the CI failure locally) the 24 failing tests now pass; full suite: 593 passed, 2 skipped. No behavior change inside a running event loop.

Fixing this also unblocks CI for #311.